### PR TITLE
Phase 2: data adapters + universe builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -243,3 +243,6 @@ setEnv.ps1
 uami_details.json
 
 documents/
+
+# Phase-2 on-disk research caches
+.data-cache/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "sqlalchemy>=2.0",
     "alembic>=1.13",
     "psycopg[binary]>=3.2",
+    "alpaca-py>=0.30",
 ]
 
 [project.optional-dependencies]
@@ -80,7 +81,7 @@ module = "tests.*"
 disallow_untyped_defs = false
 
 [[tool.mypy.overrides]]
-module = ["mcp.*"]
+module = ["mcp.*", "alpaca.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/stockripper/__main__.py
+++ b/src/stockripper/__main__.py
@@ -8,6 +8,7 @@ spawns the alpaca-mcp client and writes a track snapshot per enabled track.
 from __future__ import annotations
 
 import asyncio
+import datetime as dt
 import sys
 from dataclasses import dataclass
 from pathlib import Path
@@ -36,8 +37,12 @@ app = typer.Typer(
 )
 db_app = typer.Typer(help="Database schema management (Alembic + dev shortcuts).")
 tracks_app = typer.Typer(help="Strategy-track inspection and seeding.")
+universe_app = typer.Typer(help="Candidate universe construction and inspection.")
+research_app = typer.Typer(help="Per-symbol research probes (fundamentals, news).")
 app.add_typer(db_app, name="db")
 app.add_typer(tracks_app, name="tracks")
+app.add_typer(universe_app, name="universe")
+app.add_typer(research_app, name="research")
 console = Console()
 
 
@@ -327,6 +332,179 @@ def reconcile(
         )
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# universe
+# ---------------------------------------------------------------------------
+@universe_app.command("policies")
+def universe_policies() -> None:
+    """Print every track's universe-eligibility policy."""
+
+    from stockripper.data import DEFAULT_UNIVERSE_POLICIES
+
+    table = Table(title="Universe policies", show_header=True)
+    table.add_column("track_id", style="bold cyan")
+    table.add_column("min ADV $", justify="right")
+    table.add_column("price floor", justify="right")
+    table.add_column("cap bands")
+    table.add_column("instruments")
+    table.add_column("low-vis", justify="center")
+    for tid, pol in DEFAULT_UNIVERSE_POLICIES.items():
+        table.add_row(
+            tid,
+            f"{int(pol.min_adv_usd):,}",
+            f"{pol.price_floor_usd}",
+            ",".join(b.value for b in pol.market_cap_bands_allowed),
+            ",".join(i.value for i in pol.instrument_types_allowed),
+            "yes" if pol.low_visibility_enabled else "no",
+        )
+    console.print(table)
+
+
+@universe_app.command("build")
+def universe_build(
+    track: str = typer.Option(..., "--track", "-t", help="Track id to build the universe for."),
+    limit: int = typer.Option(50, "--limit", "-n", help="Max candidates to print."),
+) -> None:
+    """Build the candidate universe for ``track`` using live Alpaca data.
+
+    Liquidity/cap data come from Alpaca's snapshot endpoint; news count is
+    sourced from the Alpaca News API. SEC EDGAR is not hit unless the
+    track's policy enables the recent-catalyst requirement.
+    """
+
+    try:
+        settings = load_settings()
+        settings.assert_paper_only()
+    except PaperEndpointError as exc:
+        console.print(f"[bold red]Paper-endpoint check failed:[/] {exc}")
+        sys.exit(1)
+    except Exception as exc:
+        console.print(f"[bold red]Configuration error:[/] {exc}")
+        sys.exit(1)
+
+    from stockripper.data import UniverseBuilder, UniverseBuildRequest
+    from stockripper.data.live import (
+        AlpacaAssetsLoader,
+        AlpacaSnapshotProvider,
+    )
+
+    loader = AlpacaAssetsLoader(settings=settings)
+    snapshot_provider = AlpacaSnapshotProvider(settings=settings)
+    builder = UniverseBuilder(
+        assets_loader=loader,
+        snapshot_provider=snapshot_provider,
+    )
+    request = UniverseBuildRequest(
+        track_id=track,
+        as_of=dt.date.today(),
+        window_id=f"{dt.date.today().isoformat()}-open",
+        limit=limit,
+    )
+    result = builder.build(request)
+
+    table = Table(
+        title=f"Universe for {track} ({len(result.candidates)} admitted)",
+        show_header=True,
+    )
+    table.add_column("symbol", style="bold cyan")
+    table.add_column("bucket")
+    table.add_column("price", justify="right")
+    table.add_column("ADV20 $", justify="right")
+    table.add_column("cap $", justify="right")
+    table.add_column("reasons")
+    for cand in result.candidates:
+        cap = cand.snapshot.market_cap_usd
+        cap_text = f"{int(cap):,}" if cap is not None else "?"
+        reasons_text = ", ".join(r.code.value for r in cand.reasons)
+        table.add_row(
+            cand.symbol,
+            cand.bucket,
+            f"{cand.snapshot.last_price}",
+            f"{int(cand.snapshot.adv_usd_20d):,}",
+            cap_text,
+            reasons_text,
+        )
+    console.print(table)
+    console.print(f"[dim]diagnostics:[/] {result.diagnostics}")
+
+
+# ---------------------------------------------------------------------------
+# research
+# ---------------------------------------------------------------------------
+@research_app.command("fundamentals")
+def research_fundamentals(symbol: str) -> None:
+    """Print derived fundamentals (market cap, revenue, etc) for ``symbol``."""
+
+    from stockripper.data.fundamentals import derive_fundamentals
+    from stockripper.data.market_data import MarketDataAdapter
+    from stockripper.data.sec_edgar import SecEdgarClient
+
+    md = MarketDataAdapter()
+    snap = md.get_snapshot(symbol)
+    with SecEdgarClient() as edgar:
+        cik = edgar.lookup_cik(symbol)
+        if cik is None:
+            console.print(f"[bold red]No CIK for[/] {symbol}")
+            sys.exit(1)
+        facts = edgar.get_company_facts(cik)
+    fund = derive_fundamentals(facts, latest_price=snap.last_price)
+
+    table = Table(title=f"Fundamentals for {symbol} ({fund.entity_name})")
+    table.add_column("metric", style="bold cyan")
+    table.add_column("value")
+    table.add_column("as_of")
+    table.add_column("source")
+    table.add_column("confidence")
+    rows = (
+        ("shares_outstanding", fund.shares_outstanding),
+        ("revenue_ttm", fund.revenue_ttm),
+        ("net_income_ttm", fund.net_income_ttm),
+        ("total_debt", fund.total_debt),
+        ("total_equity", fund.total_equity),
+        ("debt_to_equity", fund.debt_to_equity),
+        ("market_cap", fund.market_cap),
+    )
+    for name, val in rows:
+        if val is None:
+            table.add_row(name, "—", "—", "—", "—")
+        else:
+            table.add_row(
+                name,
+                f"{val.value} {val.unit}",
+                val.as_of.isoformat(),
+                val.source_fact,
+                val.confidence,
+            )
+    console.print(table)
+
+
+@research_app.command("news")
+def research_news(
+    symbol: str,
+    days: int = typer.Option(7, "--days", "-d", help="Look-back window in days."),
+    limit: int = typer.Option(20, "--limit", "-n"),
+) -> None:
+    """Print recent headlines for ``symbol`` from the Alpaca News API."""
+
+    from stockripper.data.news import NewsAdapter
+
+    adapter = NewsAdapter()
+    since = dt.datetime.now(dt.UTC) - dt.timedelta(days=days)
+    items = adapter.get_recent_news([symbol], since=since, limit=limit)
+
+    table = Table(title=f"News for {symbol} (last {days}d, {len(items)} items)")
+    table.add_column("created_at")
+    table.add_column("headline")
+    table.add_column("source")
+    for item in items:
+        table.add_row(
+            item.created_at.isoformat(timespec="minutes"),
+            item.headline,
+            item.source or "",
+        )
+    console.print(table)
 
 
 if __name__ == "__main__":  # pragma: no cover - typer dispatch

--- a/src/stockripper/data/__init__.py
+++ b/src/stockripper/data/__init__.py
@@ -1,0 +1,43 @@
+"""Data ingestion adapters (market data, SEC EDGAR, fundamentals, news) and
+the universe builder.
+
+This package is the Phase 2 "research" surface — research workers and
+candidate-universe construction. It is intentionally **non-order-capable**:
+no module under :mod:`stockripper.data` may construct or invoke an
+Alpaca trading client. Order execution lives elsewhere (Phase 5).
+"""
+
+from stockripper.data.provenance import Provenance
+from stockripper.data.reasons import CandidateReason, CandidateReasonCode
+from stockripper.data.universe import (
+    AssetRecord,
+    AssetSnapshot,
+    Candidate,
+    SnapshotProvider,
+    UniverseBuilder,
+    UniverseBuildRequest,
+    UniverseBuildResult,
+)
+from stockripper.data.universe_policy import (
+    DEFAULT_UNIVERSE_POLICIES,
+    InstrumentType,
+    MarketCapBand,
+    UniversePolicyParams,
+)
+
+__all__ = (
+    "DEFAULT_UNIVERSE_POLICIES",
+    "AssetRecord",
+    "AssetSnapshot",
+    "Candidate",
+    "CandidateReason",
+    "CandidateReasonCode",
+    "InstrumentType",
+    "MarketCapBand",
+    "Provenance",
+    "SnapshotProvider",
+    "UniverseBuildRequest",
+    "UniverseBuildResult",
+    "UniverseBuilder",
+    "UniversePolicyParams",
+)

--- a/src/stockripper/data/cache.py
+++ b/src/stockripper/data/cache.py
@@ -1,0 +1,148 @@
+"""TTL JSON file cache used by data adapters.
+
+Design notes (per Phase 2 rubber-duck critique):
+
+- **Atomic writes.** Always write to ``<key>.tmp`` then ``os.replace`` so a
+  partial write never produces a corrupt cache file.
+- **Corrupt-file resilience.** A JSON decode error or missing version is
+  treated as a cache miss and the file is unlinked; the caller will refetch
+  and overwrite.
+- **Versioned payloads.** Each on-disk record carries a ``schema_version``
+  so future format changes are non-breaking.
+- **No concurrency promises across processes.** This is a single-process
+  TTL cache. Phase 3 may replace it with a SQL cache table if needed.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import json
+import os
+import re
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Final
+
+_SCHEMA_VERSION: Final[int] = 1
+_DEFAULT_CACHE_ROOT: Final[Path] = Path(".data-cache")
+_SAFE_KEY_RE = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def _safe_filename(key: str) -> str:
+    """Normalise an arbitrary cache key into a safe filename.
+
+    Plain keys pass through; anything containing path separators or other
+    unsafe characters is replaced with a sha256 digest so the filesystem
+    layout stays flat and predictable.
+    """
+
+    if _SAFE_KEY_RE.match(key) and len(key) <= 120:
+        return key
+    return "sha256_" + hashlib.sha256(key.encode("utf-8")).hexdigest()
+
+
+@dataclass
+class CacheEntry:
+    """In-memory view of a cache record."""
+
+    key: str
+    value: Any
+    expires_at: dt.datetime
+    written_at: dt.datetime
+
+
+class JsonFileCache:
+    """Simple TTL JSON cache backed by a directory of files.
+
+    Each provider gets its own subdirectory (``alpaca``, ``sec_edgar`` etc.)
+    so on-disk layout is human-skimmable when debugging.
+    """
+
+    def __init__(self, root: Path | str | None = None) -> None:
+        self._root = Path(root) if root is not None else _DEFAULT_CACHE_ROOT
+        self._lock = threading.Lock()
+
+    @property
+    def root(self) -> Path:
+        return self._root
+
+    def _path(self, namespace: str, key: str) -> Path:
+        return self._root / namespace / (_safe_filename(key) + ".json")
+
+    def get(self, namespace: str, key: str) -> CacheEntry | None:
+        """Return the entry if present and not expired; otherwise None."""
+
+        path = self._path(namespace, key)
+        if not path.exists():
+            return None
+        try:
+            raw = path.read_text(encoding="utf-8")
+            record = json.loads(raw)
+        except (OSError, json.JSONDecodeError):
+            with self._lock:
+                path.unlink(missing_ok=True)
+            return None
+        if record.get("schema_version") != _SCHEMA_VERSION:
+            with self._lock:
+                path.unlink(missing_ok=True)
+            return None
+        try:
+            expires_at = dt.datetime.fromisoformat(record["expires_at"])
+            written_at = dt.datetime.fromisoformat(record["written_at"])
+        except (KeyError, ValueError):
+            with self._lock:
+                path.unlink(missing_ok=True)
+            return None
+        if expires_at <= _utcnow():
+            return None
+        return CacheEntry(
+            key=key,
+            value=record["value"],
+            expires_at=expires_at,
+            written_at=written_at,
+        )
+
+    def put(
+        self,
+        namespace: str,
+        key: str,
+        value: Any,
+        *,
+        ttl: dt.timedelta,
+    ) -> CacheEntry:
+        """Write a value atomically with the requested TTL."""
+
+        now = _utcnow()
+        expires_at = now + ttl
+        record = {
+            "schema_version": _SCHEMA_VERSION,
+            "namespace": namespace,
+            "key": key,
+            "value": value,
+            "written_at": now.isoformat(),
+            "expires_at": expires_at.isoformat(),
+        }
+        path = self._path(namespace, key)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with self._lock:
+            tmp_path.write_text(
+                json.dumps(record, default=str, separators=(",", ":")),
+                encoding="utf-8",
+            )
+            os.replace(tmp_path, path)
+        return CacheEntry(key=key, value=value, expires_at=expires_at, written_at=now)
+
+    def delete(self, namespace: str, key: str) -> None:
+        path = self._path(namespace, key)
+        with self._lock:
+            path.unlink(missing_ok=True)
+
+
+__all__ = ("CacheEntry", "JsonFileCache")

--- a/src/stockripper/data/fundamentals.py
+++ b/src/stockripper/data/fundamentals.py
@@ -1,0 +1,242 @@
+"""Derive a small, honest set of fundamentals from EDGAR company-facts.
+
+Phase 2 contract: each derived datum is a :class:`FundamentalValue`
+carrying its as-of date, the source XBRL tag, a confidence label, and any
+data-quality warnings the deriver wants to flag. When the underlying facts
+are missing or ambiguous we return ``None`` rather than fabricate.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any, Literal
+
+from stockripper.data.provenance import Provenance
+from stockripper.data.sec_edgar import CompanyFacts
+
+Confidence = Literal["high", "medium", "low"]
+
+
+@dataclass(frozen=True)
+class FundamentalValue:
+    """A single derived fundamental with measurement metadata."""
+
+    value: Decimal
+    as_of: dt.date
+    source_fact: str
+    unit: str
+    confidence: Confidence
+    data_quality_warnings: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class FundamentalsSummary:
+    """Small set of derived ratios + provenance reference back to EDGAR."""
+
+    cik: str
+    entity_name: str | None
+    shares_outstanding: FundamentalValue | None
+    revenue_ttm: FundamentalValue | None
+    net_income_ttm: FundamentalValue | None
+    total_debt: FundamentalValue | None
+    total_equity: FundamentalValue | None
+    debt_to_equity: FundamentalValue | None
+    market_cap: FundamentalValue | None
+    provenance: Provenance
+
+
+_TAG_SHARES_OUT: tuple[str, ...] = (
+    "CommonStockSharesOutstanding",
+    "EntityCommonStockSharesOutstanding",
+)
+_TAG_REVENUE: tuple[str, ...] = (
+    "Revenues",
+    "RevenueFromContractWithCustomerExcludingAssessedTax",
+    "SalesRevenueNet",
+)
+_TAG_NET_INCOME: tuple[str, ...] = (
+    "NetIncomeLoss",
+)
+_TAG_DEBT_LONG: tuple[str, ...] = ("LongTermDebt", "LongTermDebtNoncurrent")
+_TAG_DEBT_SHORT: tuple[str, ...] = ("ShortTermBorrowings", "LongTermDebtCurrent")
+_TAG_EQUITY: tuple[str, ...] = (
+    "StockholdersEquity",
+    "StockholdersEquityIncludingPortionAttributableToNoncontrollingInterest",
+)
+
+
+def derive_fundamentals(
+    facts: CompanyFacts,
+    *,
+    latest_price: Decimal | None = None,
+) -> FundamentalsSummary:
+    """Compute the Phase-2 fundamentals summary from EDGAR ``CompanyFacts``."""
+
+    us_gaap = facts.facts.get("us-gaap", {}) or {}
+    dei = facts.facts.get("dei", {}) or {}
+
+    shares = _pick_instantaneous(dei, _TAG_SHARES_OUT, units=("shares",))
+    if shares is None:
+        shares = _pick_instantaneous(us_gaap, _TAG_SHARES_OUT, units=("shares",))
+    revenue = _pick_trailing_ttm(us_gaap, _TAG_REVENUE, units=("USD",))
+    net_income = _pick_trailing_ttm(us_gaap, _TAG_NET_INCOME, units=("USD",))
+    long_debt = _pick_instantaneous(us_gaap, _TAG_DEBT_LONG, units=("USD",))
+    short_debt = _pick_instantaneous(us_gaap, _TAG_DEBT_SHORT, units=("USD",))
+    equity = _pick_instantaneous(us_gaap, _TAG_EQUITY, units=("USD",))
+
+    total_debt = _combine_sum(long_debt, short_debt, fact_label="LongTermDebt+ShortTermBorrowings")
+
+    debt_to_equity: FundamentalValue | None = None
+    if total_debt is not None and equity is not None and equity.value != 0:
+        ratio = (total_debt.value / equity.value).quantize(Decimal("0.0001"))
+        warnings: tuple[str, ...] = ()
+        if total_debt.as_of != equity.as_of:
+            warnings = ("debt_equity_periods_differ",)
+        debt_to_equity = FundamentalValue(
+            value=ratio,
+            as_of=min(total_debt.as_of, equity.as_of),
+            source_fact="debt/equity",
+            unit="ratio",
+            confidence="medium" if not warnings else "low",
+            data_quality_warnings=warnings,
+        )
+
+    market_cap: FundamentalValue | None = None
+    if shares is not None and latest_price is not None and latest_price > 0:
+        warnings = ()
+        stale_days = (dt.date.today() - shares.as_of).days
+        if stale_days > 120:
+            warnings = ("shares_out_stale",)
+        market_cap = FundamentalValue(
+            value=(shares.value * latest_price).quantize(Decimal("0.01")),
+            as_of=shares.as_of,
+            source_fact=f"price*{shares.source_fact}",
+            unit="USD",
+            confidence="medium" if not warnings else "low",
+            data_quality_warnings=warnings,
+        )
+
+    return FundamentalsSummary(
+        cik=facts.cik,
+        entity_name=facts.entity_name,
+        shares_outstanding=shares,
+        revenue_ttm=revenue,
+        net_income_ttm=net_income,
+        total_debt=total_debt,
+        total_equity=equity,
+        debt_to_equity=debt_to_equity,
+        market_cap=market_cap,
+        provenance=facts.provenance,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tag pickers
+# ---------------------------------------------------------------------------
+def _pick_instantaneous(
+    namespace: dict[str, Any],
+    tags: tuple[str, ...],
+    *,
+    units: tuple[str, ...],
+) -> FundamentalValue | None:
+    """Return the most recent instantaneous-period fact from any of ``tags``."""
+
+    for tag in tags:
+        fact = namespace.get(tag)
+        if not fact:
+            continue
+        for unit in units:
+            entries = (fact.get("units") or {}).get(unit) or []
+            inst = [e for e in entries if e.get("fp") in {None, "FY"} or ("end" in e and "start" not in e)]
+            if not inst:
+                inst = [e for e in entries if "end" in e]
+            if not inst:
+                continue
+            entry = max(inst, key=lambda e: e.get("end", ""))
+            try:
+                value = Decimal(str(entry["val"]))
+                as_of = dt.date.fromisoformat(entry["end"])
+            except (KeyError, ValueError, ArithmeticError):
+                continue
+            return FundamentalValue(
+                value=value,
+                as_of=as_of,
+                source_fact=tag,
+                unit=unit,
+                confidence="high",
+            )
+    return None
+
+
+def _pick_trailing_ttm(
+    namespace: dict[str, Any],
+    tags: tuple[str, ...],
+    *,
+    units: tuple[str, ...],
+) -> FundamentalValue | None:
+    """Approximate TTM by taking the most recent annual ``FY`` value.
+
+    Computing a true trailing-twelve-month sum from quarterly facts is
+    Phase-3 work — for Phase 2 we surface the most recent FY value and tag
+    it with ``proxy_fy`` so the deriver is honest about what it returned.
+    """
+
+    for tag in tags:
+        fact = namespace.get(tag)
+        if not fact:
+            continue
+        for unit in units:
+            entries = (fact.get("units") or {}).get(unit) or []
+            annual = [e for e in entries if e.get("fp") == "FY"]
+            if not annual:
+                continue
+            entry = max(annual, key=lambda e: e.get("end", ""))
+            try:
+                value = Decimal(str(entry["val"]))
+                as_of = dt.date.fromisoformat(entry["end"])
+            except (KeyError, ValueError, ArithmeticError):
+                continue
+            return FundamentalValue(
+                value=value,
+                as_of=as_of,
+                source_fact=f"{tag}@FY",
+                unit=unit,
+                confidence="medium",
+                data_quality_warnings=("proxy_fy",),
+            )
+    return None
+
+
+def _combine_sum(
+    a: FundamentalValue | None,
+    b: FundamentalValue | None,
+    *,
+    fact_label: str,
+) -> FundamentalValue | None:
+    if a is None and b is None:
+        return None
+    if a is None:
+        return b
+    if b is None:
+        return a
+    warnings: tuple[str, ...] = ()
+    if a.as_of != b.as_of:
+        warnings = ("component_periods_differ",)
+    return FundamentalValue(
+        value=a.value + b.value,
+        as_of=min(a.as_of, b.as_of),
+        source_fact=fact_label,
+        unit=a.unit,
+        confidence="medium" if not warnings else "low",
+        data_quality_warnings=warnings,
+    )
+
+
+__all__ = (
+    "Confidence",
+    "FundamentalValue",
+    "FundamentalsSummary",
+    "derive_fundamentals",
+)

--- a/src/stockripper/data/live.py
+++ b/src/stockripper/data/live.py
@@ -1,0 +1,105 @@
+"""Live wiring: connects the pluggable :class:`UniverseBuilder` to Alpaca.
+
+Pulled into its own module so unit tests of the builder don't accidentally
+import alpaca-py and so the builder remains driveable from fakes.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable, Mapping
+
+from stockripper.config import StockripperSettings
+from stockripper.data.market_data import MarketDataAdapter
+from stockripper.data.news import NewsAdapter
+from stockripper.data.universe import AssetRecord, AssetSnapshot
+
+# These tickers / fragments are heuristic — leveraged ETF metadata isn't
+# available from the Alpaca asset list directly, so we tag a small allow-list
+# of obvious examples. Fully populating this is a Phase 3 problem.
+_LEVERAGED_ETF_HINTS: tuple[str, ...] = (
+    "TQQQ", "SQQQ", "SPXL", "SPXS", "SOXL", "SOXS", "TNA", "TZA",
+    "UPRO", "SPXU", "FAZ", "FAS", "UVXY", "SVXY", "LABU", "LABD",
+)
+
+
+class AlpacaAssetsLoader:
+    """Callable that returns the tradable equity universe from Alpaca."""
+
+    def __init__(self, *, settings: StockripperSettings | None = None) -> None:
+        from stockripper.integrations.alpaca import build_paper_reference_client
+
+        self._client = build_paper_reference_client(settings)
+
+    def __call__(self) -> Iterable[AssetRecord]:
+        from alpaca.trading.enums import AssetClass, AssetStatus
+        from alpaca.trading.requests import GetAssetsRequest
+
+        req = GetAssetsRequest(asset_class=AssetClass.US_EQUITY, status=AssetStatus.ACTIVE)
+        for asset in self._client.get_all_assets(req):
+            symbol = getattr(asset, "symbol", None)
+            if not symbol:
+                continue
+            is_etf = bool(
+                getattr(asset, "attributes", None)
+                and "etf" in {str(a).lower() for a in asset.attributes}
+            )
+            yield AssetRecord(
+                symbol=str(symbol).upper(),
+                name=str(getattr(asset, "name", "") or ""),
+                exchange=str(getattr(asset, "exchange", "") or ""),
+                tradable=bool(getattr(asset, "tradable", False)),
+                shortable=bool(getattr(asset, "shortable", False)),
+                fractionable=bool(getattr(asset, "fractionable", False)),
+                is_etf=is_etf,
+                is_leveraged_etf=str(symbol).upper() in _LEVERAGED_ETF_HINTS,
+            )
+
+
+class AlpacaSnapshotProvider:
+    """Bulk snapshot provider backed by Alpaca data + news clients.
+
+    Phase-2 strategy: we don't fetch market-cap from Alpaca (it's not in the
+    snapshot endpoint) — we leave ``market_cap_usd=None`` and let the
+    universe filter reject anything that doesn't have a band when the
+    track's policy requires one. Phase 3 will batch SEC EDGAR
+    shares-outstanding lookups to populate this.
+    """
+
+    def __init__(
+        self,
+        *,
+        settings: StockripperSettings | None = None,
+        market: MarketDataAdapter | None = None,
+        news: NewsAdapter | None = None,
+        adv_days: int = 20,
+    ) -> None:
+        self._market = market if market is not None else MarketDataAdapter()
+        self._news = news if news is not None else NewsAdapter()
+        self._adv_days = adv_days
+
+    def get_snapshots(
+        self, symbols: Iterable[str], *, as_of: dt.date,
+    ) -> Mapping[str, AssetSnapshot]:
+        out: dict[str, AssetSnapshot] = {}
+        for symbol in symbols:
+            symbol = symbol.upper()
+            try:
+                snap = self._market.get_snapshot(symbol)
+                adv = self._market.compute_adv_usd(symbol, days=self._adv_days)
+            except Exception:
+                continue
+            if snap.last_price is None:
+                continue
+            out[symbol] = AssetSnapshot(
+                symbol=symbol,
+                last_price=snap.last_price,
+                adv_usd_20d=adv.adv_usd,
+                market_cap_usd=None,
+                recent_8k_within_days=None,
+                recent_news_count_30d=None,
+            )
+        return out
+
+
+__all__ = ("AlpacaAssetsLoader", "AlpacaSnapshotProvider")

--- a/src/stockripper/data/market_data.py
+++ b/src/stockripper/data/market_data.py
@@ -1,0 +1,245 @@
+"""Market-data adapter built on alpaca-py.
+
+Returns provenance-tagged dataclasses. **Non-order-capable** — there is no
+path through this module that can submit, cancel, or replace an Alpaca
+order.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+from stockripper.data.provenance import Provenance
+from stockripper.integrations.alpaca import (
+    StockDataLike,
+    build_stock_data_client,
+)
+
+_ALPACA_DATA_BASE: str = "alpaca-data://stocks"
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+@dataclass(frozen=True)
+class Bar:
+    timestamp: dt.datetime
+    open: Decimal
+    high: Decimal
+    low: Decimal
+    close: Decimal
+    volume: int
+
+    @property
+    def dollar_volume(self) -> Decimal:
+        return self.close * Decimal(self.volume)
+
+
+@dataclass(frozen=True)
+class Quote:
+    symbol: str
+    bid_price: Decimal
+    ask_price: Decimal
+    timestamp: dt.datetime
+    provenance: Provenance
+
+
+@dataclass(frozen=True)
+class Snapshot:
+    symbol: str
+    last_price: Decimal | None
+    last_trade_at: dt.datetime | None
+    daily_volume: int | None
+    provenance: Provenance
+
+
+@dataclass(frozen=True)
+class AdvResult:
+    """20- or 30-day average dollar volume result with provenance."""
+
+    symbol: str
+    window_days: int
+    adv_usd: Decimal
+    bars_used: int
+    provenance: Provenance
+
+
+class MarketDataAdapter:
+    """Thin, typed facade over the alpaca-py historical stock-data client."""
+
+    def __init__(self, client: StockDataLike | None = None) -> None:
+        self._client = client if client is not None else build_stock_data_client()
+
+    # ------------------------------------------------------------------
+    # Snapshot / quote
+    # ------------------------------------------------------------------
+    def get_snapshot(self, symbol: str) -> Snapshot:
+        from alpaca.data.requests import StockSnapshotRequest
+
+        symbol = symbol.upper()
+        req = StockSnapshotRequest(symbol_or_symbols=symbol)
+        result = self._client.get_stock_snapshot(req)
+        raw = _select(result, symbol)
+        latest_trade = getattr(raw, "latest_trade", None)
+        daily_bar = getattr(raw, "daily_bar", None)
+        prov = Provenance.for_payload(
+            provider="alpaca_data",
+            source_url=f"{_ALPACA_DATA_BASE}/{symbol}/snapshot",
+            payload=_to_jsonable(raw),
+            request_key=f"snapshot:{symbol}",
+        )
+        return Snapshot(
+            symbol=symbol,
+            last_price=_decimal(getattr(latest_trade, "price", None)),
+            last_trade_at=getattr(latest_trade, "timestamp", None),
+            daily_volume=_int(getattr(daily_bar, "volume", None)),
+            provenance=prov,
+        )
+
+    def get_latest_quote(self, symbol: str) -> Quote:
+        from alpaca.data.requests import StockLatestQuoteRequest
+
+        symbol = symbol.upper()
+        req = StockLatestQuoteRequest(symbol_or_symbols=symbol)
+        result = self._client.get_stock_latest_quote(req)
+        raw = _select(result, symbol)
+        prov = Provenance.for_payload(
+            provider="alpaca_data",
+            source_url=f"{_ALPACA_DATA_BASE}/{symbol}/quotes/latest",
+            payload=_to_jsonable(raw),
+            request_key=f"latest_quote:{symbol}",
+        )
+        return Quote(
+            symbol=symbol,
+            bid_price=_decimal(getattr(raw, "bid_price", None)) or Decimal("0"),
+            ask_price=_decimal(getattr(raw, "ask_price", None)) or Decimal("0"),
+            timestamp=getattr(raw, "timestamp", _utcnow()),
+            provenance=prov,
+        )
+
+    # ------------------------------------------------------------------
+    # Bars + ADV
+    # ------------------------------------------------------------------
+    def get_daily_bars(self, symbol: str, *, days: int) -> tuple[tuple[Bar, ...], Provenance]:
+        from alpaca.data.requests import StockBarsRequest
+        from alpaca.data.timeframe import TimeFrame
+
+        if days <= 0:
+            raise ValueError("days must be positive")
+        symbol = symbol.upper()
+        end = _utcnow()
+        # Add a small buffer so weekends/holidays don't shrink the window.
+        start = end - dt.timedelta(days=int(days * 1.6) + 2)
+        req = StockBarsRequest(
+            symbol_or_symbols=symbol,
+            timeframe=TimeFrame.Day,
+            start=start,
+            end=end,
+        )
+        result = self._client.get_stock_bars(req)
+        bars_raw = _bars_from_result(result, symbol)
+        bars = tuple(
+            Bar(
+                timestamp=b.timestamp,
+                open=Decimal(str(b.open)),
+                high=Decimal(str(b.high)),
+                low=Decimal(str(b.low)),
+                close=Decimal(str(b.close)),
+                volume=int(b.volume or 0),
+            )
+            for b in bars_raw
+        )[-days:]
+        prov = Provenance.for_payload(
+            provider="alpaca_data",
+            source_url=f"{_ALPACA_DATA_BASE}/{symbol}/bars/day",
+            payload=[_to_jsonable(b) for b in bars_raw],
+            request_key=f"daily_bars:{symbol}:{days}d",
+        )
+        return bars, prov
+
+    def compute_adv_usd(self, symbol: str, *, days: int = 20) -> AdvResult:
+        bars, prov = self.get_daily_bars(symbol, days=days)
+        warnings: list[str] = []
+        if len(bars) < max(5, days // 2):
+            warnings.append("insufficient_history")
+        if bars:
+            adv = sum((b.dollar_volume for b in bars), start=Decimal("0")) / Decimal(len(bars))
+        else:
+            adv = Decimal("0")
+            warnings.append("no_bars")
+        if warnings:
+            prov = prov.model_copy(update={"data_quality_warnings": tuple(warnings)})
+        return AdvResult(
+            symbol=symbol.upper(),
+            window_days=days,
+            adv_usd=adv.quantize(Decimal("0.01")),
+            bars_used=len(bars),
+            provenance=prov,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _select(result: Any, symbol: str) -> Any:
+    """alpaca-py returns a dict for batch calls; normalise to a single object."""
+
+    if isinstance(result, dict):
+        return result.get(symbol) or result.get(symbol.upper()) or next(iter(result.values()))
+    return result
+
+
+def _bars_from_result(result: Any, symbol: str) -> list[Any]:
+    if isinstance(result, dict):
+        return list(result.get(symbol) or result.get(symbol.upper()) or [])
+    data = getattr(result, "data", None)
+    if isinstance(data, dict):
+        return list(data.get(symbol) or data.get(symbol.upper()) or [])
+    return list(data or [])
+
+
+def _decimal(value: Any) -> Decimal | None:
+    if value is None:
+        return None
+    try:
+        return Decimal(str(value))
+    except (ValueError, ArithmeticError):
+        return None
+
+
+def _int(value: Any) -> int | None:
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_jsonable(obj: Any) -> Any:
+    """Best-effort conversion of alpaca-py model objects to JSON-friendly dicts."""
+
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    if isinstance(obj, (list, tuple)):
+        return [_to_jsonable(x) for x in obj]
+    if isinstance(obj, dict):
+        return {str(k): _to_jsonable(v) for k, v in obj.items()}
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json")
+    if hasattr(obj, "__dict__"):
+        return {k: _to_jsonable(v) for k, v in vars(obj).items() if not k.startswith("_")}
+    return str(obj)
+
+
+__all__ = (
+    "AdvResult",
+    "Bar",
+    "MarketDataAdapter",
+    "Quote",
+    "Snapshot",
+)

--- a/src/stockripper/data/news.py
+++ b/src/stockripper/data/news.py
@@ -1,0 +1,144 @@
+"""Alpaca News API adapter.
+
+Returns provenance-tagged :class:`NewsItem` records. The adapter is
+intentionally read-only and non-order-capable.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Any
+
+from stockripper.data.provenance import Provenance
+from stockripper.integrations.alpaca import NewsClientLike, build_news_client
+
+_ALPACA_NEWS_BASE: str = "alpaca-data://news"
+
+
+@dataclass(frozen=True)
+class NewsItem:
+    id: str
+    headline: str
+    summary: str
+    author: str | None
+    url: str | None
+    symbols: tuple[str, ...]
+    created_at: dt.datetime
+    updated_at: dt.datetime | None
+    source: str | None
+    provenance: Provenance
+
+
+class NewsAdapter:
+    """Thin wrapper around alpaca-py's NewsClient."""
+
+    def __init__(self, client: NewsClientLike | None = None) -> None:
+        self._client = client if client is not None else build_news_client()
+
+    def get_recent_news(
+        self,
+        symbols: list[str] | tuple[str, ...],
+        *,
+        since: dt.datetime | None = None,
+        limit: int = 50,
+    ) -> tuple[NewsItem, ...]:
+        from alpaca.data.requests import NewsRequest
+
+        if not symbols:
+            return ()
+        upper_symbols = [s.upper() for s in symbols]
+        kwargs: dict[str, Any] = {"symbols": ",".join(upper_symbols), "limit": limit}
+        if since is not None:
+            kwargs["start"] = since
+        req = NewsRequest(**kwargs)
+        result = self._client.get_news(req)
+        raw_items = _items_from_result(result)
+        out: list[NewsItem] = []
+        for raw in raw_items:
+            prov = Provenance.for_payload(
+                provider="alpaca_news",
+                source_url=f"{_ALPACA_NEWS_BASE}/{getattr(raw, 'id', '?')}",
+                payload=_to_jsonable(raw),
+                request_key=f"news:{','.join(upper_symbols)}:{since}:{limit}",
+            )
+            out.append(_to_news_item(raw, prov))
+        return tuple(out)
+
+    def count_recent_news(
+        self,
+        symbol: str,
+        *,
+        since: dt.datetime,
+        limit: int = 100,
+    ) -> int:
+        """Used by the low-visibility filter to count items in a window."""
+
+        return len(self.get_recent_news([symbol], since=since, limit=limit))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+def _items_from_result(result: Any) -> list[Any]:
+    if isinstance(result, list):
+        return result
+    if isinstance(result, dict):
+        # Alpaca returns {"news": [...]} for some surfaces.
+        items = result.get("news") or result.get("data") or []
+        if isinstance(items, dict):
+            # Older shape: {"AAPL": [...]} — flatten.
+            flat: list[Any] = []
+            for v in items.values():
+                if isinstance(v, list):
+                    flat.extend(v)
+            return flat
+        return list(items)
+    data = getattr(result, "data", None) or getattr(result, "news", None)
+    if isinstance(data, dict):
+        flat = []
+        for v in data.values():
+            if isinstance(v, list):
+                flat.extend(v)
+        return flat
+    return list(data or [])
+
+
+def _to_news_item(raw: Any, provenance: Provenance) -> NewsItem:
+    symbols = getattr(raw, "symbols", None) or []
+    return NewsItem(
+        id=str(getattr(raw, "id", "")),
+        headline=str(getattr(raw, "headline", "") or ""),
+        summary=str(getattr(raw, "summary", "") or ""),
+        author=_opt_str(getattr(raw, "author", None)),
+        url=_opt_str(getattr(raw, "url", None)),
+        symbols=tuple(str(s).upper() for s in symbols),
+        created_at=getattr(raw, "created_at", None) or dt.datetime.now(dt.UTC),
+        updated_at=getattr(raw, "updated_at", None),
+        source=_opt_str(getattr(raw, "source", None)),
+        provenance=provenance,
+    )
+
+
+def _opt_str(v: Any) -> str | None:
+    if v is None:
+        return None
+    s = str(v)
+    return s if s else None
+
+
+def _to_jsonable(obj: Any) -> Any:
+    if obj is None or isinstance(obj, (str, int, float, bool)):
+        return obj
+    if isinstance(obj, (list, tuple)):
+        return [_to_jsonable(x) for x in obj]
+    if isinstance(obj, dict):
+        return {str(k): _to_jsonable(v) for k, v in obj.items()}
+    if hasattr(obj, "model_dump"):
+        return obj.model_dump(mode="json")
+    if hasattr(obj, "__dict__"):
+        return {k: _to_jsonable(v) for k, v in vars(obj).items() if not k.startswith("_")}
+    return str(obj)
+
+
+__all__ = ("NewsAdapter", "NewsItem")

--- a/src/stockripper/data/provenance.py
+++ b/src/stockripper/data/provenance.py
@@ -1,0 +1,77 @@
+"""Shared provenance record stamped on every external datum.
+
+Phase 2 keeps this in adapter return values; Phase 3 will mechanically
+persist it into a ``data_provenance`` table without the adapters changing.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+class Provenance(BaseModel):
+    """Where this datum came from and how to prove it.
+
+    ``content_hash`` is sha256 over the raw provider payload (after parse
+    but before adapter normalisation) so two ingests of bit-identical
+    content collapse to the same hash even if metadata differs.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    provider: str = Field(..., description="Short provider id, e.g. 'sec_edgar', 'alpaca_data'.")
+    source_url: str = Field(..., description="Canonical URL the data was retrieved from.")
+    retrieved_at: dt.datetime = Field(default_factory=_utcnow)
+    content_hash: str = Field(..., min_length=64, max_length=64)
+    request_key: str | None = Field(
+        default=None,
+        description="Stable cache key for the request (provider + endpoint + params).",
+    )
+    data_quality_warnings: tuple[str, ...] = Field(
+        default=(),
+        description="Adapter-emitted warnings such as 'shares_out_stale' or 'partial_facts'.",
+    )
+
+    @classmethod
+    def for_payload(
+        cls,
+        *,
+        provider: str,
+        source_url: str,
+        payload: Any,
+        request_key: str | None = None,
+        retrieved_at: dt.datetime | None = None,
+        data_quality_warnings: tuple[str, ...] = (),
+    ) -> Provenance:
+        """Build a Provenance with ``content_hash`` derived from ``payload``."""
+
+        hasher = hashlib.sha256()
+        if isinstance(payload, (bytes, bytearray)):
+            hasher.update(bytes(payload))
+        elif isinstance(payload, str):
+            hasher.update(payload.encode("utf-8"))
+        else:
+            import json
+
+            hasher.update(
+                json.dumps(payload, sort_keys=True, default=str, separators=(",", ":")).encode("utf-8")
+            )
+        return cls(
+            provider=provider,
+            source_url=source_url,
+            content_hash=hasher.hexdigest(),
+            request_key=request_key,
+            retrieved_at=retrieved_at if retrieved_at is not None else _utcnow(),
+            data_quality_warnings=data_quality_warnings,
+        )
+
+
+__all__ = ("Provenance",)

--- a/src/stockripper/data/reasons.py
+++ b/src/stockripper/data/reasons.py
@@ -1,0 +1,50 @@
+"""Typed reason codes attached to each universe candidate.
+
+Reason codes are enum values, not free-form strings, so the dashboard and
+analytics layer can filter, count, and chart them without parsing prose.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import StrEnum
+from typing import Any
+
+
+class CandidateReasonCode(StrEnum):
+    """Why a symbol was admitted (or kept) in a track's candidate set."""
+
+    PASSES_ADV_FLOOR = "passes_adv_floor"
+    PASSES_PRICE_FLOOR = "passes_price_floor"
+    IN_MARKET_CAP_BAND = "in_market_cap_band"
+    INSTRUMENT_ALLOWED = "instrument_allowed"
+    HAS_RECENT_8K = "has_recent_8k"
+    LOW_VISIBILITY = "low_visibility"
+    HIDDEN_GEM_BUCKET = "hidden_gem_bucket"
+    BENCHMARK_HOLDING = "benchmark_holding"
+    RANDOM_BASELINE_PICK = "random_baseline_pick"
+    QUANT_SIGNAL_HIT = "quant_signal_hit"
+
+
+@dataclass(frozen=True)
+class CandidateReason:
+    """A single typed reason with structured parameters.
+
+    ``params`` is intentionally a free-form dict so each code can carry the
+    measurement that satisfied it (e.g. ``{"adv_usd": 12_300_000.0,
+    "floor_usd": 5_000_000.0}``) without inflating the enum.
+    """
+
+    code: CandidateReasonCode
+    params: dict[str, Any] = field(default_factory=dict)
+
+    def render(self) -> str:
+        """Compact human-readable form for Rich tables / CLI output."""
+
+        if not self.params:
+            return self.code.value
+        bits = ",".join(f"{k}={v}" for k, v in self.params.items())
+        return f"{self.code.value}({bits})"
+
+
+__all__ = ("CandidateReason", "CandidateReasonCode")

--- a/src/stockripper/data/sec_edgar.py
+++ b/src/stockripper/data/sec_edgar.py
@@ -1,0 +1,320 @@
+"""SEC EDGAR HTTP adapter.
+
+Honors SEC fair-access guidance:[^sec-edgar]
+
+- Sends a meaningful ``User-Agent`` containing contact info (required).
+- Process-wide ceiling of 10 requests/second across all clients (the SEC
+  documented limit).
+- Bounded retries with backoff on 429/5xx.
+
+[^sec-edgar]: https://www.sec.gov/search-filings/edgar-application-programming-interfaces
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+import threading
+import time
+from collections import deque
+from dataclasses import dataclass
+from typing import Any, Final
+
+import httpx
+
+from stockripper.data.cache import JsonFileCache
+from stockripper.data.provenance import Provenance
+
+_EDGAR_SUBMISSIONS_BASE: Final[str] = "https://data.sec.gov/submissions"
+_EDGAR_COMPANY_FACTS_BASE: Final[str] = "https://data.sec.gov/api/xbrl/companyfacts"
+_EDGAR_TICKER_LOOKUP: Final[str] = "https://www.sec.gov/files/company_tickers.json"
+
+_MAX_RPS: Final[int] = 10
+_RATE_WINDOW: Final[float] = 1.0
+
+
+class SecEdgarConfigError(RuntimeError):
+    """Raised when SEC EDGAR access is misconfigured (e.g., missing User-Agent)."""
+
+
+def _resolve_user_agent() -> str:
+    """Return a non-empty SEC-compliant User-Agent string.
+
+    SEC requires identifying contact information; a bare app name is
+    insufficient. We enforce that the value contains an ``@`` so it's
+    clearly a contact, not a placeholder.
+    """
+
+    ua = os.environ.get("SEC_EDGAR_USER_AGENT", "").strip()
+    if not ua:
+        raise SecEdgarConfigError(
+            "SEC_EDGAR_USER_AGENT must be set to something like "
+            "'StockRipper paper-research-bot ops@example.com' before calling EDGAR."
+        )
+    if "@" not in ua:
+        raise SecEdgarConfigError(
+            "SEC_EDGAR_USER_AGENT must include a contact email "
+            "(SEC fair-access requirement)."
+        )
+    return ua
+
+
+class _ProcessRateLimiter:
+    """Sliding-window limiter — at most ``_MAX_RPS`` calls per second across the process."""
+
+    def __init__(self, max_rps: int = _MAX_RPS, window: float = _RATE_WINDOW) -> None:
+        self._max = max_rps
+        self._window = window
+        self._timestamps: deque[float] = deque()
+        self._lock = threading.Lock()
+
+    def acquire(self) -> None:
+        while True:
+            with self._lock:
+                now = time.monotonic()
+                while self._timestamps and now - self._timestamps[0] >= self._window:
+                    self._timestamps.popleft()
+                if len(self._timestamps) < self._max:
+                    self._timestamps.append(now)
+                    return
+                sleep_for = self._window - (now - self._timestamps[0])
+            time.sleep(max(sleep_for, 0.01))
+
+
+_RATE_LIMITER: _ProcessRateLimiter = _ProcessRateLimiter()
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class Filing:
+    accession_number: str
+    form: str
+    filing_date: dt.date
+    primary_document: str | None
+
+
+@dataclass(frozen=True)
+class CompanyFacts:
+    cik: str
+    entity_name: str | None
+    facts: dict[str, Any]
+    provenance: Provenance
+
+
+@dataclass(frozen=True)
+class CompanySubmissions:
+    cik: str
+    entity_name: str | None
+    recent_filings: tuple[Filing, ...]
+    provenance: Provenance
+
+
+# ---------------------------------------------------------------------------
+# Client
+# ---------------------------------------------------------------------------
+class SecEdgarClient:
+    """Cached httpx client for SEC EDGAR endpoints used in Phase 2."""
+
+    def __init__(
+        self,
+        *,
+        cache: JsonFileCache | None = None,
+        http: httpx.Client | None = None,
+        user_agent: str | None = None,
+        max_retries: int = 3,
+        ttl_company_facts: dt.timedelta = dt.timedelta(hours=12),
+        ttl_submissions: dt.timedelta = dt.timedelta(hours=1),
+        ttl_ticker_map: dt.timedelta = dt.timedelta(days=1),
+    ) -> None:
+        self._cache = cache if cache is not None else JsonFileCache()
+        ua = user_agent if user_agent is not None else _resolve_user_agent()
+        self._http = http if http is not None else httpx.Client(
+            headers={"User-Agent": ua, "Accept": "application/json"},
+            timeout=httpx.Timeout(15.0, connect=5.0),
+        )
+        self._max_retries = max_retries
+        self._ttl_company_facts = ttl_company_facts
+        self._ttl_submissions = ttl_submissions
+        self._ttl_ticker_map = ttl_ticker_map
+
+    def close(self) -> None:
+        self._http.close()
+
+    def __enter__(self) -> SecEdgarClient:
+        return self
+
+    def __exit__(self, *exc: object) -> None:
+        self.close()
+
+    # ------------------------------------------------------------------
+    # Ticker -> CIK
+    # ------------------------------------------------------------------
+    def lookup_cik(self, ticker: str) -> str | None:
+        """Return the zero-padded 10-digit CIK for ``ticker`` or ``None``."""
+
+        mapping = self._get_ticker_map()
+        upper = ticker.upper()
+        for entry in mapping.values():
+            if isinstance(entry, dict) and str(entry.get("ticker", "")).upper() == upper:
+                cik_int = int(entry["cik_str"])
+                return f"{cik_int:010d}"
+        return None
+
+    def _get_ticker_map(self) -> dict[str, Any]:
+        ns, key = "sec_edgar", "company_tickers"
+        cached = self._cache.get(ns, key)
+        if cached is not None:
+            return dict(cached.value)
+        payload = self._get_json(_EDGAR_TICKER_LOOKUP)
+        self._cache.put(ns, key, payload, ttl=self._ttl_ticker_map)
+        return dict(payload)
+
+    # ------------------------------------------------------------------
+    # Submissions (form list)
+    # ------------------------------------------------------------------
+    def get_submissions(self, cik: str) -> CompanySubmissions:
+        cik = _normalise_cik(cik)
+        ns, key = "sec_edgar", f"submissions_{cik}"
+        cached = self._cache.get(ns, key)
+        if cached is not None:
+            payload = cached.value
+        else:
+            url = f"{_EDGAR_SUBMISSIONS_BASE}/CIK{cik}.json"
+            payload = self._get_json(url)
+            self._cache.put(ns, key, payload, ttl=self._ttl_submissions)
+        recent = payload.get("filings", {}).get("recent", {}) or {}
+        filings = _zip_filings(recent)
+        prov = Provenance.for_payload(
+            provider="sec_edgar",
+            source_url=f"{_EDGAR_SUBMISSIONS_BASE}/CIK{cik}.json",
+            payload=payload,
+            request_key=key,
+        )
+        return CompanySubmissions(
+            cik=cik,
+            entity_name=payload.get("name"),
+            recent_filings=tuple(filings),
+            provenance=prov,
+        )
+
+    def get_recent_filings(
+        self,
+        cik: str,
+        *,
+        forms: tuple[str, ...] = ("8-K", "10-Q", "10-K", "S-1"),
+        within_days: int | None = None,
+    ) -> tuple[Filing, ...]:
+        subs = self.get_submissions(cik)
+        cutoff: dt.date | None = None
+        if within_days is not None:
+            cutoff = dt.date.today() - dt.timedelta(days=within_days)
+        out: list[Filing] = []
+        for f in subs.recent_filings:
+            if forms and f.form not in forms:
+                continue
+            if cutoff is not None and f.filing_date < cutoff:
+                continue
+            out.append(f)
+        return tuple(out)
+
+    # ------------------------------------------------------------------
+    # Company facts (XBRL)
+    # ------------------------------------------------------------------
+    def get_company_facts(self, cik: str) -> CompanyFacts:
+        cik = _normalise_cik(cik)
+        ns, key = "sec_edgar", f"company_facts_{cik}"
+        cached = self._cache.get(ns, key)
+        if cached is not None:
+            payload = cached.value
+        else:
+            url = f"{_EDGAR_COMPANY_FACTS_BASE}/CIK{cik}.json"
+            payload = self._get_json(url)
+            self._cache.put(ns, key, payload, ttl=self._ttl_company_facts)
+        prov = Provenance.for_payload(
+            provider="sec_edgar",
+            source_url=f"{_EDGAR_COMPANY_FACTS_BASE}/CIK{cik}.json",
+            payload=payload,
+            request_key=key,
+        )
+        return CompanyFacts(
+            cik=cik,
+            entity_name=payload.get("entityName"),
+            facts=payload.get("facts", {}) or {},
+            provenance=prov,
+        )
+
+    # ------------------------------------------------------------------
+    # HTTP
+    # ------------------------------------------------------------------
+    def _get_json(self, url: str) -> dict[str, Any]:
+        last_exc: Exception | None = None
+        for attempt in range(self._max_retries + 1):
+            _RATE_LIMITER.acquire()
+            try:
+                resp = self._http.get(url)
+            except httpx.HTTPError as exc:
+                last_exc = exc
+                if attempt >= self._max_retries:
+                    raise
+                time.sleep(0.5 * (2 ** attempt))
+                continue
+            if resp.status_code == 429 or 500 <= resp.status_code < 600:
+                last_exc = httpx.HTTPStatusError(
+                    f"SEC EDGAR returned {resp.status_code}",
+                    request=resp.request,
+                    response=resp,
+                )
+                if attempt >= self._max_retries:
+                    raise last_exc
+                time.sleep(0.5 * (2 ** attempt))
+                continue
+            resp.raise_for_status()
+            data = resp.json()
+            if not isinstance(data, dict):
+                raise RuntimeError(f"SEC EDGAR returned non-object JSON for {url}")
+            return data
+        if last_exc is not None:
+            raise last_exc
+        raise RuntimeError("SEC EDGAR request failed without an exception")
+
+
+def _normalise_cik(cik: str | int) -> str:
+    text = str(cik).strip().lstrip("CIK").lstrip("cik")
+    if not text:
+        raise ValueError("CIK cannot be empty")
+    return f"{int(text):010d}"
+
+
+def _zip_filings(recent: dict[str, Any]) -> list[Filing]:
+    forms = recent.get("form") or []
+    accessions = recent.get("accessionNumber") or []
+    filing_dates = recent.get("filingDate") or []
+    primary_docs = recent.get("primaryDocument") or []
+    out: list[Filing] = []
+    for i, form in enumerate(forms):
+        try:
+            filing_date = dt.date.fromisoformat(filing_dates[i])
+        except (IndexError, ValueError):
+            continue
+        accession = accessions[i] if i < len(accessions) else ""
+        primary = primary_docs[i] if i < len(primary_docs) else None
+        out.append(
+            Filing(
+                accession_number=str(accession),
+                form=str(form),
+                filing_date=filing_date,
+                primary_document=str(primary) if primary else None,
+            )
+        )
+    return out
+
+
+__all__ = (
+    "CompanyFacts",
+    "CompanySubmissions",
+    "Filing",
+    "SecEdgarClient",
+    "SecEdgarConfigError",
+)

--- a/src/stockripper/data/universe.py
+++ b/src/stockripper/data/universe.py
@@ -1,0 +1,282 @@
+"""Universe builder.
+
+Given a per-track :class:`UniversePolicyParams`, produces a deterministic
+ordered list of :class:`Candidate` symbols with structured
+:class:`CandidateReason` records describing exactly why each symbol was
+admitted.
+
+The builder is intentionally **pluggable**: market-data, fundamentals, and
+news access happen through small adapter callables so unit tests can drive
+the entire flow with deterministic in-memory fakes (no network).
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Callable, Iterable, Mapping
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Protocol
+
+from stockripper.data.reasons import CandidateReason, CandidateReasonCode
+from stockripper.data.universe_policy import (
+    DEFAULT_UNIVERSE_POLICIES,
+    InstrumentType,
+    MarketCapBand,
+    UniversePolicyParams,
+)
+
+
+# ---------------------------------------------------------------------------
+# Inputs
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class AssetRecord:
+    """Static metadata for a tradable asset."""
+
+    symbol: str
+    name: str
+    exchange: str
+    tradable: bool
+    shortable: bool
+    fractionable: bool
+    is_etf: bool = False
+    is_leveraged_etf: bool = False
+
+
+@dataclass(frozen=True)
+class AssetSnapshot:
+    """Refresh-time view of an asset used by the builder."""
+
+    symbol: str
+    last_price: Decimal
+    adv_usd_20d: Decimal
+    market_cap_usd: Decimal | None
+    recent_8k_within_days: int | None  # ``None`` if unknown / not searched
+    recent_news_count_30d: int | None  # ``None`` if not measured
+
+
+@dataclass(frozen=True)
+class UniverseBuildRequest:
+    """Deterministic input envelope for a universe build."""
+
+    track_id: str
+    as_of: dt.date
+    window_id: str
+    limit: int = 200
+
+
+@dataclass(frozen=True)
+class Candidate:
+    symbol: str
+    reasons: tuple[CandidateReason, ...]
+    bucket: str  # "core" | "hidden_gem" | "benchmark"
+    snapshot: AssetSnapshot
+
+
+@dataclass(frozen=True)
+class UniverseBuildResult:
+    request: UniverseBuildRequest
+    candidates: tuple[Candidate, ...]
+    rejected_count: int
+    diagnostics: dict[str, int] = field(default_factory=dict)
+
+
+# ---------------------------------------------------------------------------
+# Adapter contracts
+# ---------------------------------------------------------------------------
+class SnapshotProvider(Protocol):
+    """Returns refresh-time snapshot info for a given asset universe.
+
+    Implementations may batch, cache, or stream; the universe builder only
+    cares that calling with the same inputs produces the same outputs.
+    """
+
+    def get_snapshots(
+        self, symbols: Iterable[str], *, as_of: dt.date,
+    ) -> Mapping[str, AssetSnapshot]: ...
+
+
+# ---------------------------------------------------------------------------
+# Builder
+# ---------------------------------------------------------------------------
+@dataclass
+class UniverseBuilder:
+    """Pure-logic builder.
+
+    External I/O is delegated to two callables:
+
+    - ``assets_loader`` returns the static tradable-asset list.
+    - ``snapshot_provider`` returns refresh-time per-symbol data.
+    """
+
+    assets_loader: Callable[[], Iterable[AssetRecord]]
+    snapshot_provider: SnapshotProvider
+    policies: Mapping[str, UniversePolicyParams] = field(
+        default_factory=lambda: DEFAULT_UNIVERSE_POLICIES
+    )
+
+    def build(self, request: UniverseBuildRequest) -> UniverseBuildResult:
+        policy = self.policies.get(request.track_id)
+        if policy is None:
+            raise KeyError(f"No universe policy registered for track {request.track_id!r}")
+
+        assets = [a for a in self.assets_loader() if a.tradable]
+        snapshots = self.snapshot_provider.get_snapshots(
+            (a.symbol for a in assets), as_of=request.as_of,
+        )
+
+        diagnostics: dict[str, int] = {
+            "total_assets": len(assets),
+            "missing_snapshot": 0,
+            "rejected_price_floor": 0,
+            "rejected_adv_floor": 0,
+            "rejected_cap_band": 0,
+            "rejected_instrument": 0,
+            "admitted_core": 0,
+            "admitted_low_visibility": 0,
+        }
+        admitted: list[Candidate] = []
+
+        for asset in assets:
+            snap = snapshots.get(asset.symbol.upper())
+            if snap is None:
+                diagnostics["missing_snapshot"] += 1
+                continue
+
+            verdict = _evaluate(asset, snap, policy)
+            if verdict.kind == "admit":
+                bucket = verdict.bucket
+                if bucket == "hidden_gem":
+                    diagnostics["admitted_low_visibility"] += 1
+                else:
+                    diagnostics["admitted_core"] += 1
+                admitted.append(
+                    Candidate(
+                        symbol=asset.symbol.upper(),
+                        reasons=tuple(verdict.reasons),
+                        bucket=bucket,
+                        snapshot=snap,
+                    )
+                )
+            else:
+                diagnostics[verdict.reject_key] = diagnostics.get(verdict.reject_key, 0) + 1
+
+        admitted.sort(key=lambda c: (-int(c.snapshot.adv_usd_20d), c.symbol))
+        truncated = admitted[: request.limit]
+        return UniverseBuildResult(
+            request=request,
+            candidates=tuple(truncated),
+            rejected_count=len(assets) - len(truncated),
+            diagnostics=diagnostics,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Per-asset evaluation
+# ---------------------------------------------------------------------------
+@dataclass(frozen=True)
+class _Verdict:
+    kind: str  # "admit" | "reject"
+    reasons: tuple[CandidateReason, ...] = ()
+    bucket: str = "core"
+    reject_key: str = ""
+
+
+def _evaluate(
+    asset: AssetRecord, snap: AssetSnapshot, policy: UniversePolicyParams,
+) -> _Verdict:
+    reasons: list[CandidateReason] = []
+
+    instrument = _classify_instrument(asset)
+    if instrument not in policy.instrument_types_allowed:
+        return _Verdict(kind="reject", reject_key="rejected_instrument")
+    reasons.append(
+        CandidateReason(
+            code=CandidateReasonCode.INSTRUMENT_ALLOWED,
+            params={"instrument": instrument.value},
+        )
+    )
+
+    if snap.last_price < policy.price_floor_usd:
+        return _Verdict(kind="reject", reject_key="rejected_price_floor")
+    reasons.append(
+        CandidateReason(
+            code=CandidateReasonCode.PASSES_PRICE_FLOOR,
+            params={"price": float(snap.last_price), "floor": float(policy.price_floor_usd)},
+        )
+    )
+
+    if snap.adv_usd_20d < policy.min_adv_usd:
+        return _Verdict(kind="reject", reject_key="rejected_adv_floor")
+    reasons.append(
+        CandidateReason(
+            code=CandidateReasonCode.PASSES_ADV_FLOOR,
+            params={"adv_usd": float(snap.adv_usd_20d), "floor": float(policy.min_adv_usd)},
+        )
+    )
+
+    band = MarketCapBand.classify(snap.market_cap_usd)
+    if band is None or band not in policy.market_cap_bands_allowed:
+        return _Verdict(kind="reject", reject_key="rejected_cap_band")
+    reasons.append(
+        CandidateReason(
+            code=CandidateReasonCode.IN_MARKET_CAP_BAND,
+            params={"band": band.value},
+        )
+    )
+
+    bucket = "core"
+    if policy.low_visibility_enabled and _is_low_visibility(snap, policy, band):
+        bucket = "hidden_gem"
+        reasons.append(
+            CandidateReason(
+                code=CandidateReasonCode.LOW_VISIBILITY,
+                params={
+                    "news_30d": snap.recent_news_count_30d,
+                    "max_allowed": policy.low_visibility_max_news_30d,
+                },
+            )
+        )
+        if policy.require_recent_catalyst_days is not None and snap.recent_8k_within_days is not None:
+            reasons.append(
+                CandidateReason(
+                    code=CandidateReasonCode.HAS_RECENT_8K,
+                    params={"within_days": snap.recent_8k_within_days},
+                )
+            )
+        reasons.append(CandidateReason(code=CandidateReasonCode.HIDDEN_GEM_BUCKET))
+
+    return _Verdict(kind="admit", reasons=tuple(reasons), bucket=bucket)
+
+
+def _classify_instrument(asset: AssetRecord) -> InstrumentType:
+    if asset.is_leveraged_etf:
+        return InstrumentType.LEVERAGED_ETF
+    if asset.is_etf:
+        return InstrumentType.ETF
+    return InstrumentType.EQUITY_LONG
+
+
+def _is_low_visibility(
+    snap: AssetSnapshot, policy: UniversePolicyParams, band: MarketCapBand,
+) -> bool:
+    # Restrict to small/micro/nano caps — anything bigger isn't "low visibility".
+    if band not in {MarketCapBand.SMALL, MarketCapBand.MICRO, MarketCapBand.NANO}:
+        return False
+    if snap.recent_news_count_30d is None:
+        return False
+    if snap.recent_news_count_30d >= policy.low_visibility_max_news_30d:
+        return False
+    return not (policy.require_recent_catalyst_days is not None and (snap.recent_8k_within_days is None or snap.recent_8k_within_days > policy.require_recent_catalyst_days))
+
+
+__all__ = (
+    "AssetRecord",
+    "AssetSnapshot",
+    "Candidate",
+    "SnapshotProvider",
+    "UniverseBuildRequest",
+    "UniverseBuildResult",
+    "UniverseBuilder",
+)

--- a/src/stockripper/data/universe_policy.py
+++ b/src/stockripper/data/universe_policy.py
@@ -1,0 +1,216 @@
+"""Per-track universe (candidate-eligibility) policy.
+
+Deliberately kept separate from :mod:`stockripper.risk`. Risk policies
+control sizing/exposure of already-chosen ideas; universe policies decide
+which symbols are even *eligible* to be considered. Conflating them in
+Phase 1 was tempting but would make Phase 5's risk-gate logic harder to
+reason about, so they live in different modules and tables.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+from enum import StrEnum
+from typing import Final
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class MarketCapBand(StrEnum):
+    """Coarse market-cap buckets used by per-track allow-lists."""
+
+    MEGA = "mega"     # > $200B
+    LARGE = "large"   # $10B-$200B
+    MID = "mid"       # $2B-$10B
+    SMALL = "small"   # $300M-$2B
+    MICRO = "micro"   # $50M-$300M
+    NANO = "nano"     # < $50M
+
+    @classmethod
+    def classify(cls, market_cap_usd: Decimal | float | int | None) -> MarketCapBand | None:
+        """Map a market-cap value to a band, or ``None`` if unknown."""
+
+        if market_cap_usd is None:
+            return None
+        cap = float(market_cap_usd)
+        if cap <= 0:
+            return None
+        if cap > 200_000_000_000:
+            return cls.MEGA
+        if cap > 10_000_000_000:
+            return cls.LARGE
+        if cap > 2_000_000_000:
+            return cls.MID
+        if cap > 300_000_000:
+            return cls.SMALL
+        if cap > 50_000_000:
+            return cls.MICRO
+        return cls.NANO
+
+
+class InstrumentType(StrEnum):
+    """Coarse instrument allow-list per track."""
+
+    EQUITY_LONG = "equity_long"
+    EQUITY_SHORT = "equity_short"
+    OPTION_SINGLE = "option_single"
+    OPTION_SPREAD = "option_spread"
+    ETF = "etf"
+    LEVERAGED_ETF = "leveraged_etf"
+
+
+_ALL_BANDS: Final[tuple[MarketCapBand, ...]] = tuple(MarketCapBand)
+
+
+class UniversePolicyParams(BaseModel):
+    """Per-track candidate-eligibility knobs.
+
+    Stored in the ``risk_policies.params_json`` blob alongside risk knobs in
+    Phase 2 (no schema change required), but kept as a separate Pydantic
+    model so the conceptual boundary is clear.
+    """
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    min_adv_usd: Decimal = Field(
+        ..., description="Hard liquidity floor: 20-day average dollar volume.",
+    )
+    price_floor_usd: Decimal = Field(
+        ..., description="Reject penny names below this last price.",
+    )
+    market_cap_bands_allowed: tuple[MarketCapBand, ...] = Field(
+        default=_ALL_BANDS,
+        description="Which market-cap bands are eligible.",
+    )
+    instrument_types_allowed: tuple[InstrumentType, ...] = Field(
+        ..., description="Which instrument types this track may trade.",
+    )
+    low_visibility_enabled: bool = Field(
+        default=False,
+        description="Whether the low-visibility (hidden-gem) bucket is searched.",
+    )
+    low_visibility_max_news_30d: int = Field(
+        default=2,
+        ge=0,
+        description="Symbols with strictly fewer than this many news items in 30d qualify as low-visibility.",
+    )
+    require_recent_catalyst_days: int | None = Field(
+        default=None,
+        description=(
+            "If set, the low-visibility bucket additionally requires an 8-K within "
+            "this many days. ``None`` disables that requirement."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Defaults — one per Phase-1 strategy track.
+# ---------------------------------------------------------------------------
+DEFAULT_UNIVERSE_POLICIES: Final[dict[str, UniversePolicyParams]] = {
+    "conservative": UniversePolicyParams(
+        min_adv_usd=Decimal("25000000"),
+        price_floor_usd=Decimal("10"),
+        market_cap_bands_allowed=(MarketCapBand.MEGA, MarketCapBand.LARGE),
+        instrument_types_allowed=(InstrumentType.EQUITY_LONG, InstrumentType.ETF),
+        low_visibility_enabled=False,
+    ),
+    "balanced": UniversePolicyParams(
+        min_adv_usd=Decimal("10000000"),
+        price_floor_usd=Decimal("5"),
+        market_cap_bands_allowed=(MarketCapBand.MEGA, MarketCapBand.LARGE, MarketCapBand.MID),
+        instrument_types_allowed=(
+            InstrumentType.EQUITY_LONG,
+            InstrumentType.ETF,
+            InstrumentType.OPTION_SINGLE,
+        ),
+        low_visibility_enabled=False,
+    ),
+    "aggressive": UniversePolicyParams(
+        min_adv_usd=Decimal("2000000"),
+        price_floor_usd=Decimal("2"),
+        market_cap_bands_allowed=(
+            MarketCapBand.MEGA,
+            MarketCapBand.LARGE,
+            MarketCapBand.MID,
+            MarketCapBand.SMALL,
+        ),
+        instrument_types_allowed=(
+            InstrumentType.EQUITY_LONG,
+            InstrumentType.EQUITY_SHORT,
+            InstrumentType.ETF,
+            InstrumentType.LEVERAGED_ETF,
+            InstrumentType.OPTION_SINGLE,
+            InstrumentType.OPTION_SPREAD,
+        ),
+        low_visibility_enabled=True,
+        low_visibility_max_news_30d=3,
+        require_recent_catalyst_days=14,
+    ),
+    "concentrated": UniversePolicyParams(
+        min_adv_usd=Decimal("10000000"),
+        price_floor_usd=Decimal("5"),
+        market_cap_bands_allowed=(
+            MarketCapBand.MEGA,
+            MarketCapBand.LARGE,
+            MarketCapBand.MID,
+        ),
+        instrument_types_allowed=(
+            InstrumentType.EQUITY_LONG,
+            InstrumentType.EQUITY_SHORT,
+            InstrumentType.OPTION_SINGLE,
+            InstrumentType.OPTION_SPREAD,
+        ),
+        low_visibility_enabled=False,
+    ),
+    "yolo": UniversePolicyParams(
+        min_adv_usd=Decimal("500000"),
+        price_floor_usd=Decimal("0.5"),
+        market_cap_bands_allowed=_ALL_BANDS,
+        instrument_types_allowed=tuple(InstrumentType),
+        low_visibility_enabled=True,
+        low_visibility_max_news_30d=10,
+        require_recent_catalyst_days=None,
+    ),
+    "quant_signal": UniversePolicyParams(
+        min_adv_usd=Decimal("5000000"),
+        price_floor_usd=Decimal("3"),
+        market_cap_bands_allowed=(
+            MarketCapBand.MEGA,
+            MarketCapBand.LARGE,
+            MarketCapBand.MID,
+            MarketCapBand.SMALL,
+        ),
+        instrument_types_allowed=(
+            InstrumentType.EQUITY_LONG,
+            InstrumentType.EQUITY_SHORT,
+            InstrumentType.ETF,
+        ),
+        low_visibility_enabled=False,
+    ),
+    "random_baseline": UniversePolicyParams(
+        min_adv_usd=Decimal("10000000"),
+        price_floor_usd=Decimal("5"),
+        market_cap_bands_allowed=(
+            MarketCapBand.MEGA,
+            MarketCapBand.LARGE,
+            MarketCapBand.MID,
+        ),
+        instrument_types_allowed=(InstrumentType.EQUITY_LONG, InstrumentType.ETF),
+        low_visibility_enabled=False,
+    ),
+    "benchmark": UniversePolicyParams(
+        min_adv_usd=Decimal("50000000"),
+        price_floor_usd=Decimal("20"),
+        market_cap_bands_allowed=(MarketCapBand.MEGA, MarketCapBand.LARGE),
+        instrument_types_allowed=(InstrumentType.ETF,),
+        low_visibility_enabled=False,
+    ),
+}
+
+
+__all__ = (
+    "DEFAULT_UNIVERSE_POLICIES",
+    "InstrumentType",
+    "MarketCapBand",
+    "UniversePolicyParams",
+)

--- a/src/stockripper/integrations/__init__.py
+++ b/src/stockripper/integrations/__init__.py
@@ -1,0 +1,11 @@
+"""Internal Alpaca client factories shared by data adapters.
+
+This package is the *internal* boundary above ``alpaca-py``. The MCP server
+(``tools/alpaca_mcp``) remains the agent-facing surface; this module is the
+research/data-ingestion path used by the universe builder and friends.
+
+Critical guarantee: nothing in :mod:`stockripper.data` may import the
+trading client from here. The trading-client factory lives in
+:mod:`stockripper.execution` (Phase 5) so research code is structurally
+incapable of submitting orders.
+"""

--- a/src/stockripper/integrations/alpaca/__init__.py
+++ b/src/stockripper/integrations/alpaca/__init__.py
@@ -1,0 +1,96 @@
+"""Paper-only Alpaca data + news client factories.
+
+Order-capable clients are deliberately *not* exposed here so research code
+cannot construct them. Phase 5's execution adapter owns the
+:class:`alpaca.trading.client.TradingClient` factory in a different module.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Protocol
+
+from stockripper.config import StockripperSettings, load_settings
+
+
+class StockDataLike(Protocol):
+    """Minimal protocol the market-data adapter relies on.
+
+    Defined as a protocol so unit tests can drop in a fake without depending
+    on alpaca-py being installed in the test environment.
+    """
+
+    def get_stock_snapshot(self, request: Any) -> Any: ...
+    def get_stock_bars(self, request: Any) -> Any: ...
+    def get_stock_latest_quote(self, request: Any) -> Any: ...
+
+
+class NewsClientLike(Protocol):
+    def get_news(self, request: Any) -> Any: ...
+
+
+class TradingClientLike(Protocol):
+    """Read-only trading-client surface exposed for ``get_all_assets``."""
+
+    def get_all_assets(self, filter: Any | None = None) -> Any: ...
+
+
+def _credentials(settings: StockripperSettings | None) -> tuple[str, str]:
+    cfg = settings if settings is not None else load_settings()
+    cfg.assert_paper_only()
+    return (
+        cfg.alpaca_api_key_id.get_secret_value(),
+        cfg.alpaca_api_secret_key.get_secret_value(),
+    )
+
+
+def build_stock_data_client(
+    settings: StockripperSettings | None = None,
+) -> StockDataLike:
+    """Return an alpaca-py historical stock-data client."""
+
+    from alpaca.data.historical.stock import StockHistoricalDataClient
+
+    key_id, secret = _credentials(settings)
+    return StockHistoricalDataClient(api_key=key_id, secret_key=secret)
+
+
+def build_news_client(
+    settings: StockripperSettings | None = None,
+) -> NewsClientLike:
+    """Return an alpaca-py news client."""
+
+    from alpaca.data.historical.news import NewsClient
+
+    key_id, secret = _credentials(settings)
+    return NewsClient(api_key=key_id, secret_key=secret)
+
+
+def build_paper_reference_client(
+    settings: StockripperSettings | None = None,
+) -> TradingClientLike:
+    """Return a *reference-only* paper trading client.
+
+    Yes, this is technically ``alpaca.trading.client.TradingClient`` — but
+    we expose it via the :class:`TradingClientLike` protocol that only
+    advertises ``get_all_assets``, and the function name signals intent.
+    The Phase 2 universe builder needs the tradable-asset list; nothing
+    else.
+
+    For order submission, use the execution-adapter factory in Phase 5,
+    *not* this function.
+    """
+
+    from alpaca.trading.client import TradingClient
+
+    key_id, secret = _credentials(settings)
+    return TradingClient(api_key=key_id, secret_key=secret, paper=True)
+
+
+__all__ = (
+    "NewsClientLike",
+    "StockDataLike",
+    "TradingClientLike",
+    "build_news_client",
+    "build_paper_reference_client",
+    "build_stock_data_client",
+)

--- a/tests/test_data_cache.py
+++ b/tests/test_data_cache.py
@@ -1,0 +1,67 @@
+"""Tests for the atomic JSON file cache."""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+from pathlib import Path
+
+from stockripper.data.cache import JsonFileCache
+
+
+def test_put_then_get_returns_value(tmp_path: Path) -> None:
+    cache = JsonFileCache(tmp_path)
+    cache.put("alpaca", "bars:AAPL:20d", {"hello": "world"}, ttl=dt.timedelta(minutes=1))
+    entry = cache.get("alpaca", "bars:AAPL:20d")
+    assert entry is not None
+    assert entry.value == {"hello": "world"}
+
+
+def test_get_after_expiry_returns_none(tmp_path: Path) -> None:
+    cache = JsonFileCache(tmp_path)
+    cache.put("p", "k", 42, ttl=dt.timedelta(seconds=-5))  # already expired
+    assert cache.get("p", "k") is None
+
+
+def test_corrupt_file_treated_as_miss_and_removed(tmp_path: Path) -> None:
+    cache = JsonFileCache(tmp_path)
+    path = tmp_path / "p" / "k.json"
+    path.parent.mkdir()
+    path.write_text("{not valid json", encoding="utf-8")
+    assert cache.get("p", "k") is None
+    assert not path.exists()
+
+
+def test_unknown_schema_version_is_invalidated(tmp_path: Path) -> None:
+    cache = JsonFileCache(tmp_path)
+    path = tmp_path / "p" / "k.json"
+    path.parent.mkdir()
+    path.write_text(json.dumps({"schema_version": 999, "value": 1}), encoding="utf-8")
+    assert cache.get("p", "k") is None
+    assert not path.exists()
+
+
+def test_unsafe_key_is_hashed(tmp_path: Path) -> None:
+    cache = JsonFileCache(tmp_path)
+    weird = "a/b/c:1?q=2"
+    cache.put("p", weird, "ok", ttl=dt.timedelta(minutes=1))
+    files = list((tmp_path / "p").iterdir())
+    assert len(files) == 1
+    assert files[0].name.startswith("sha256_")
+    entry = cache.get("p", weird)
+    assert entry is not None and entry.value == "ok"
+
+
+def test_atomic_write_no_tmp_leftovers(tmp_path: Path) -> None:
+    cache = JsonFileCache(tmp_path)
+    for i in range(5):
+        cache.put("p", f"k{i}", i, ttl=dt.timedelta(minutes=1))
+    leftovers = [p for p in (tmp_path / "p").iterdir() if p.suffix == ".tmp"]
+    assert leftovers == []
+
+
+def test_delete_removes_entry(tmp_path: Path) -> None:
+    cache = JsonFileCache(tmp_path)
+    cache.put("p", "k", "v", ttl=dt.timedelta(minutes=1))
+    cache.delete("p", "k")
+    assert cache.get("p", "k") is None

--- a/tests/test_data_fundamentals.py
+++ b/tests/test_data_fundamentals.py
@@ -1,0 +1,110 @@
+"""Tests for :func:`derive_fundamentals`."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from typing import Any
+
+from stockripper.data.fundamentals import derive_fundamentals
+from stockripper.data.provenance import Provenance
+from stockripper.data.sec_edgar import CompanyFacts
+
+
+def _facts(payload: dict[str, Any]) -> CompanyFacts:
+    return CompanyFacts(
+        cik="0000123456",
+        entity_name="Test Co",
+        facts=payload,
+        provenance=Provenance.for_payload(
+            provider="sec_edgar",
+            source_url="https://data.sec.gov/api/xbrl/companyfacts/CIK0000123456.json",
+            payload={},
+        ),
+    )
+
+
+def test_returns_nones_when_namespaces_empty() -> None:
+    summary = derive_fundamentals(_facts({}))
+    assert summary.shares_outstanding is None
+    assert summary.revenue_ttm is None
+    assert summary.net_income_ttm is None
+    assert summary.total_debt is None
+    assert summary.total_equity is None
+    assert summary.debt_to_equity is None
+    assert summary.market_cap is None
+
+
+def test_derives_shares_revenue_and_market_cap() -> None:
+    today = dt.date.today()
+    recent = today - dt.timedelta(days=30)
+    payload = {
+        "dei": {
+            "EntityCommonStockSharesOutstanding": {
+                "units": {
+                    "shares": [
+                        {"val": 1_000_000_000, "end": recent.isoformat(), "fp": "FY"},
+                    ]
+                }
+            }
+        },
+        "us-gaap": {
+            "Revenues": {
+                "units": {
+                    "USD": [
+                        {"val": 50_000_000_000, "end": recent.isoformat(), "fp": "FY"},
+                    ]
+                }
+            },
+            "NetIncomeLoss": {
+                "units": {
+                    "USD": [
+                        {"val": 5_000_000_000, "end": recent.isoformat(), "fp": "FY"},
+                    ]
+                }
+            },
+            "LongTermDebt": {
+                "units": {
+                    "USD": [
+                        {"val": 10_000_000_000, "end": recent.isoformat()},
+                    ]
+                }
+            },
+            "StockholdersEquity": {
+                "units": {
+                    "USD": [
+                        {"val": 20_000_000_000, "end": recent.isoformat()},
+                    ]
+                }
+            },
+        },
+    }
+    summary = derive_fundamentals(_facts(payload), latest_price=Decimal("150"))
+    assert summary.shares_outstanding is not None
+    assert summary.shares_outstanding.value == Decimal("1000000000")
+    assert summary.revenue_ttm is not None
+    assert summary.revenue_ttm.value == Decimal("50000000000")
+    assert "proxy_fy" in summary.revenue_ttm.data_quality_warnings
+    assert summary.market_cap is not None
+    assert summary.market_cap.value == Decimal("150000000000.00")
+    assert summary.debt_to_equity is not None
+    assert summary.debt_to_equity.value == Decimal("0.5000")
+
+
+def test_market_cap_warns_when_shares_stale() -> None:
+    long_ago = dt.date.today() - dt.timedelta(days=200)
+    payload = {
+        "dei": {
+            "EntityCommonStockSharesOutstanding": {
+                "units": {
+                    "shares": [
+                        {"val": 100_000_000, "end": long_ago.isoformat(), "fp": "FY"},
+                    ]
+                }
+            }
+        }
+    }
+    summary = derive_fundamentals(_facts(payload), latest_price=Decimal("10"))
+    assert summary.market_cap is not None
+    assert "shares_out_stale" in summary.market_cap.data_quality_warnings
+    assert summary.market_cap.confidence == "low"

--- a/tests/test_data_market_data.py
+++ b/tests/test_data_market_data.py
@@ -1,0 +1,125 @@
+"""Tests for :class:`MarketDataAdapter`."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from stockripper.data.market_data import MarketDataAdapter
+
+
+@dataclass
+class _FakeBar:
+    timestamp: dt.datetime
+    open: float
+    high: float
+    low: float
+    close: float
+    volume: int
+
+
+@dataclass
+class _FakeTrade:
+    price: float
+    timestamp: dt.datetime
+
+
+@dataclass
+class _FakeDailyBar:
+    volume: int
+
+
+@dataclass
+class _FakeSnapshot:
+    latest_trade: _FakeTrade
+    daily_bar: _FakeDailyBar
+
+
+@dataclass
+class _FakeQuote:
+    bid_price: float
+    ask_price: float
+    timestamp: dt.datetime
+
+
+class _FakeStockClient:
+    def __init__(self, bars: list[_FakeBar] | None = None) -> None:
+        self._bars = bars or []
+
+    def get_stock_snapshot(self, request: Any) -> dict[str, _FakeSnapshot]:
+        return {
+            "AAPL": _FakeSnapshot(
+                latest_trade=_FakeTrade(price=150.25, timestamp=dt.datetime.now(dt.UTC)),
+                daily_bar=_FakeDailyBar(volume=1_000_000),
+            )
+        }
+
+    def get_stock_bars(self, request: Any) -> dict[str, list[_FakeBar]]:
+        return {"AAPL": list(self._bars)}
+
+    def get_stock_latest_quote(self, request: Any) -> dict[str, _FakeQuote]:
+        return {
+            "AAPL": _FakeQuote(
+                bid_price=149.99,
+                ask_price=150.01,
+                timestamp=dt.datetime.now(dt.UTC),
+            )
+        }
+
+
+def _make_bars(n: int, *, close: float = 100.0, volume: int = 1_000_000) -> list[_FakeBar]:
+    today = dt.datetime.now(dt.UTC)
+    return [
+        _FakeBar(
+            timestamp=today - dt.timedelta(days=n - i),
+            open=close,
+            high=close,
+            low=close,
+            close=close,
+            volume=volume,
+        )
+        for i in range(n)
+    ]
+
+
+def test_get_snapshot_normalises_alpaca_response() -> None:
+    adapter = MarketDataAdapter(client=_FakeStockClient())
+    snap = adapter.get_snapshot("aapl")
+    assert snap.symbol == "AAPL"
+    assert snap.last_price == Decimal("150.25")
+    assert snap.daily_volume == 1_000_000
+    assert snap.provenance.provider == "alpaca_data"
+    assert len(snap.provenance.content_hash) == 64
+
+
+def test_get_latest_quote_returns_provenance() -> None:
+    adapter = MarketDataAdapter(client=_FakeStockClient())
+    q = adapter.get_latest_quote("aapl")
+    assert q.bid_price == Decimal("149.99")
+    assert q.ask_price == Decimal("150.01")
+
+
+def test_compute_adv_usd_averages_dollar_volume() -> None:
+    bars = _make_bars(20, close=100.0, volume=1_000_000)
+    adapter = MarketDataAdapter(client=_FakeStockClient(bars=bars))
+    adv = adapter.compute_adv_usd("aapl", days=20)
+    assert adv.adv_usd == Decimal("100000000.00")
+    assert adv.bars_used == 20
+    assert "insufficient_history" not in adv.provenance.data_quality_warnings
+
+
+def test_compute_adv_usd_warns_on_short_history() -> None:
+    bars = _make_bars(3, close=10.0, volume=10_000)
+    adapter = MarketDataAdapter(client=_FakeStockClient(bars=bars))
+    adv = adapter.compute_adv_usd("aapl", days=20)
+    assert "insufficient_history" in adv.provenance.data_quality_warnings
+
+
+def test_get_daily_bars_rejects_non_positive_days() -> None:
+    adapter = MarketDataAdapter(client=_FakeStockClient())
+    with pytest.raises(ValueError):
+        adapter.get_daily_bars("AAPL", days=0)

--- a/tests/test_data_news.py
+++ b/tests/test_data_news.py
@@ -1,0 +1,76 @@
+"""Tests for :class:`NewsAdapter`."""
+
+from __future__ import annotations
+
+import datetime as dt
+from dataclasses import dataclass
+from typing import Any
+
+from stockripper.data.news import NewsAdapter
+
+
+@dataclass
+class _FakeRawNews:
+    id: int
+    headline: str
+    summary: str
+    author: str
+    url: str
+    symbols: list[str]
+    created_at: dt.datetime
+    updated_at: dt.datetime
+    source: str
+
+
+class _FakeNewsClient:
+    def __init__(self, items: list[_FakeRawNews]) -> None:
+        self._items = items
+        self.calls: list[Any] = []
+
+    def get_news(self, request: Any) -> list[_FakeRawNews]:
+        self.calls.append(request)
+        return list(self._items)
+
+
+def _items(n: int) -> list[_FakeRawNews]:
+    base = dt.datetime.now(dt.UTC) - dt.timedelta(days=1)
+    return [
+        _FakeRawNews(
+            id=i,
+            headline=f"Headline {i}",
+            summary=f"Summary {i}",
+            author="Reporter",
+            url=f"https://example.com/{i}",
+            symbols=["AAPL"],
+            created_at=base + dt.timedelta(minutes=i),
+            updated_at=base + dt.timedelta(minutes=i),
+            source="benzinga",
+        )
+        for i in range(n)
+    ]
+
+
+def test_get_recent_news_returns_provenance_tagged_items() -> None:
+    fake = _FakeNewsClient(_items(3))
+    adapter = NewsAdapter(client=fake)
+    out = adapter.get_recent_news(["aapl"], since=dt.datetime.now(dt.UTC) - dt.timedelta(days=2))
+    assert len(out) == 3
+    for item in out:
+        assert item.symbols == ("AAPL",)
+        assert item.provenance.provider == "alpaca_news"
+
+
+def test_count_recent_news_returns_int() -> None:
+    fake = _FakeNewsClient(_items(7))
+    adapter = NewsAdapter(client=fake)
+    count = adapter.count_recent_news(
+        "AAPL", since=dt.datetime.now(dt.UTC) - dt.timedelta(days=2)
+    )
+    assert count == 7
+
+
+def test_get_recent_news_empty_symbols_short_circuits() -> None:
+    fake = _FakeNewsClient(_items(5))
+    adapter = NewsAdapter(client=fake)
+    assert adapter.get_recent_news([]) == ()
+    assert fake.calls == []

--- a/tests/test_data_provenance.py
+++ b/tests/test_data_provenance.py
@@ -1,0 +1,49 @@
+"""Tests for the Provenance pydantic model."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import ValidationError
+
+from stockripper.data.provenance import Provenance
+
+
+def test_for_payload_is_deterministic_for_dicts() -> None:
+    a = Provenance.for_payload(
+        provider="sec_edgar",
+        source_url="https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json",
+        payload={"b": 2, "a": 1},
+    )
+    b = Provenance.for_payload(
+        provider="sec_edgar",
+        source_url="https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json",
+        payload={"a": 1, "b": 2},  # different key order, same content
+    )
+    assert a.content_hash == b.content_hash
+    assert len(a.content_hash) == 64
+
+
+def test_for_payload_handles_bytes_and_strings() -> None:
+    raw = b'{"hi":1}'
+    a = Provenance.for_payload(provider="x", source_url="x://1", payload=raw)
+    b = Provenance.for_payload(provider="x", source_url="x://1", payload=raw.decode("utf-8"))
+    # bytes hashed directly; string hashed as utf-8 bytes of the literal,
+    # which equals the byte content, so both should match.
+    assert a.content_hash == b.content_hash
+
+
+def test_provenance_is_frozen() -> None:
+    p = Provenance.for_payload(provider="x", source_url="x://1", payload={"a": 1})
+    with pytest.raises((ValidationError, TypeError)):
+        p.provider = "other"
+
+
+def test_extra_fields_are_rejected() -> None:
+    p = Provenance.for_payload(provider="x", source_url="x://1", payload={"a": 1})
+    raw = p.model_dump_json()
+    payload = json.loads(raw)
+    payload["unknown"] = "field"
+    with pytest.raises(ValidationError):
+        Provenance.model_validate(payload)

--- a/tests/test_data_sec_edgar.py
+++ b/tests/test_data_sec_edgar.py
@@ -1,0 +1,185 @@
+"""Tests for :mod:`stockripper.data.sec_edgar` using mocked httpx + rate limiter."""
+
+from __future__ import annotations
+
+import datetime as dt
+import threading
+import time
+from typing import Any
+
+import httpx
+import pytest
+
+from stockripper.data.cache import JsonFileCache
+from stockripper.data.sec_edgar import (
+    SecEdgarClient,
+    SecEdgarConfigError,
+    _ProcessRateLimiter,
+    _resolve_user_agent,
+)
+
+
+@pytest.fixture
+def cache(tmp_path: Any) -> JsonFileCache:
+    return JsonFileCache(tmp_path / "cache")
+
+
+def _mock_transport(routes: dict[str, dict[str, Any]]) -> httpx.MockTransport:
+    """Return a transport that maps URLs to JSON payloads (or status codes)."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        spec = routes.get(str(request.url))
+        if spec is None:
+            return httpx.Response(404, json={"detail": "no route"})
+        if "status" in spec:
+            return httpx.Response(spec["status"], json=spec.get("json", {}))
+        return httpx.Response(200, json=spec["json"])
+
+    return httpx.MockTransport(handler)
+
+
+def _client(transport: httpx.MockTransport, cache: JsonFileCache) -> SecEdgarClient:
+    http = httpx.Client(
+        transport=transport,
+        headers={"User-Agent": "StockRipper test ops@example.com"},
+        timeout=5.0,
+    )
+    return SecEdgarClient(http=http, cache=cache, user_agent="StockRipper test ops@example.com")
+
+
+def test_user_agent_requires_email(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SEC_EDGAR_USER_AGENT", "StockRipper paper-bot")
+    with pytest.raises(SecEdgarConfigError):
+        _resolve_user_agent()
+
+
+def test_user_agent_required(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("SEC_EDGAR_USER_AGENT", raising=False)
+    with pytest.raises(SecEdgarConfigError):
+        _resolve_user_agent()
+
+
+def test_lookup_cik_returns_padded_value(cache: JsonFileCache) -> None:
+    routes = {
+        "https://www.sec.gov/files/company_tickers.json": {
+            "json": {
+                "0": {"cik_str": 320193, "ticker": "AAPL", "title": "APPLE INC"},
+                "1": {"cik_str": 789019, "ticker": "MSFT", "title": "MICROSOFT CORP"},
+            }
+        },
+    }
+    client = _client(_mock_transport(routes), cache)
+    try:
+        cik = client.lookup_cik("aapl")
+        assert cik == "0000320193"
+        assert client.lookup_cik("nope") is None
+    finally:
+        client.close()
+
+
+def test_get_company_facts_round_trips_and_caches(cache: JsonFileCache) -> None:
+    url = "https://data.sec.gov/api/xbrl/companyfacts/CIK0000320193.json"
+    routes = {
+        url: {
+            "json": {
+                "entityName": "Apple Inc.",
+                "facts": {"dei": {"EntityCommonStockSharesOutstanding": {}}},
+            }
+        },
+    }
+    client = _client(_mock_transport(routes), cache)
+    try:
+        first = client.get_company_facts("320193")
+        assert first.entity_name == "Apple Inc."
+        assert first.cik == "0000320193"
+        # Second call should hit the cache (no extra route registration needed).
+        second = client.get_company_facts("320193")
+        assert second.entity_name == first.entity_name
+        assert second.provenance.content_hash == first.provenance.content_hash
+    finally:
+        client.close()
+
+
+def test_get_submissions_parses_filings(cache: JsonFileCache) -> None:
+    url = "https://data.sec.gov/submissions/CIK0000320193.json"
+    routes = {
+        url: {
+            "json": {
+                "name": "Apple Inc.",
+                "filings": {
+                    "recent": {
+                        "form": ["8-K", "10-Q", "8-K"],
+                        "accessionNumber": ["a-1", "a-2", "a-3"],
+                        "filingDate": [
+                            (dt.date.today() - dt.timedelta(days=5)).isoformat(),
+                            (dt.date.today() - dt.timedelta(days=60)).isoformat(),
+                            (dt.date.today() - dt.timedelta(days=400)).isoformat(),
+                        ],
+                        "primaryDocument": ["d1.htm", "d2.htm", "d3.htm"],
+                    }
+                },
+            }
+        }
+    }
+    client = _client(_mock_transport(routes), cache)
+    try:
+        recent_8k = client.get_recent_filings("320193", forms=("8-K",), within_days=30)
+        assert len(recent_8k) == 1
+        assert recent_8k[0].accession_number == "a-1"
+    finally:
+        client.close()
+
+
+def test_retries_on_429_then_succeeds(
+    cache: JsonFileCache, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return httpx.Response(429, json={"detail": "rate limited"})
+        return httpx.Response(200, json={"entityName": "X", "facts": {}})
+
+    http = httpx.Client(
+        transport=httpx.MockTransport(handler),
+        headers={"User-Agent": "StockRipper test ops@example.com"},
+        timeout=5.0,
+    )
+    client = SecEdgarClient(http=http, cache=cache, user_agent="ua ops@example.com", max_retries=2)
+    try:
+        # Patch backoff sleeps so this test stays fast.
+        monkeypatch.setattr("stockripper.data.sec_edgar.time.sleep", lambda _x: None)
+        facts = client.get_company_facts("1")
+        assert facts.entity_name == "X"
+        assert calls["n"] == 2
+    finally:
+        client.close()
+
+
+def test_process_rate_limiter_blocks_when_full() -> None:
+    limiter = _ProcessRateLimiter(max_rps=2, window=0.2)
+    # Burn the budget — first 2 are immediate, 3rd must wait roughly window.
+    limiter.acquire()
+    limiter.acquire()
+    start = time.monotonic()
+    limiter.acquire()
+    elapsed = time.monotonic() - start
+    assert elapsed >= 0.15, f"limiter did not block (elapsed={elapsed})"
+
+
+def test_process_rate_limiter_is_thread_safe() -> None:
+    # Hammer the limiter from N threads and ensure no double-count.
+    limiter = _ProcessRateLimiter(max_rps=5, window=0.5)
+    barrier = threading.Barrier(10)
+
+    def worker() -> None:
+        barrier.wait()
+        limiter.acquire()
+
+    threads = [threading.Thread(target=worker) for _ in range(10)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=3.0)
+        assert not t.is_alive()

--- a/tests/test_data_universe.py
+++ b/tests/test_data_universe.py
@@ -1,0 +1,185 @@
+"""Universe-builder acceptance + filter tests.
+
+Drives the pluggable :class:`UniverseBuilder` with a synthetic 300-asset
+corpus + in-memory snapshot provider so the test is fully offline.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import random
+from collections.abc import Iterable, Mapping
+from decimal import Decimal
+
+import pytest
+
+from stockripper.data import (
+    DEFAULT_UNIVERSE_POLICIES,
+    AssetRecord,
+    AssetSnapshot,
+    CandidateReasonCode,
+    SnapshotProvider,
+    UniverseBuilder,
+    UniverseBuildRequest,
+)
+
+
+def _synthetic_assets(n: int = 300) -> tuple[AssetRecord, ...]:
+    rng = random.Random(20260527)
+    out: list[AssetRecord] = []
+    for i in range(n):
+        symbol = f"SYM{i:03d}"
+        is_etf = (i % 25 == 0)
+        is_lev = (i % 75 == 0)
+        out.append(
+            AssetRecord(
+                symbol=symbol,
+                name=f"Synthetic Co {i}",
+                exchange=rng.choice(("NASDAQ", "NYSE", "ARCA")),
+                tradable=True,
+                shortable=(i % 3 == 0),
+                fractionable=True,
+                is_etf=is_etf,
+                is_leveraged_etf=is_lev,
+            )
+        )
+    return tuple(out)
+
+
+class _InMemorySnapshotProvider(SnapshotProvider):
+    def __init__(self, snapshots: Mapping[str, AssetSnapshot]) -> None:
+        self._snapshots = snapshots
+
+    def get_snapshots(
+        self, symbols: Iterable[str], *, as_of: dt.date,
+    ) -> Mapping[str, AssetSnapshot]:
+        return self._snapshots
+
+
+def _synthetic_snapshots(assets: Iterable[AssetRecord]) -> dict[str, AssetSnapshot]:
+    rng = random.Random(20260527)
+    out: dict[str, AssetSnapshot] = {}
+    for i, asset in enumerate(assets):
+        # Build a wide spread across cap bands, prices, ADV so most tracks
+        # see plenty of candidates and at least one nano-cap qualifies for
+        # YOLO's low-visibility bucket.
+        cap_buckets = [
+            500_000_000_000,    # mega
+            50_000_000_000,     # large
+            5_000_000_000,      # mid
+            800_000_000,        # small
+            150_000_000,        # micro
+            25_000_000,         # nano
+        ]
+        cap = Decimal(str(cap_buckets[i % len(cap_buckets)]))
+        price = Decimal(str(rng.uniform(0.5, 500.0))).quantize(Decimal("0.01"))
+        # Volume scaled to cap so liquidity filters bind realistically.
+        base_adv = float(cap) * rng.uniform(0.0005, 0.005)
+        adv = Decimal(f"{base_adv:.2f}")
+        news_30d = rng.randint(0, 12)
+        # Every 11th nano/micro has a recent 8-K — that's our hidden-gem set.
+        recent_8k = 5 if (i % 11 == 0 and cap < 300_000_000) else None
+        out[asset.symbol] = AssetSnapshot(
+            symbol=asset.symbol,
+            last_price=price,
+            adv_usd_20d=adv,
+            market_cap_usd=cap,
+            recent_8k_within_days=recent_8k,
+            recent_news_count_30d=news_30d,
+        )
+    return out
+
+
+@pytest.fixture
+def builder() -> UniverseBuilder:
+    assets = _synthetic_assets(300)
+    snaps = _synthetic_snapshots(assets)
+    return UniverseBuilder(
+        assets_loader=lambda: assets,
+        snapshot_provider=_InMemorySnapshotProvider(snaps),
+    )
+
+
+def _request(track: str, limit: int = 200) -> UniverseBuildRequest:
+    return UniverseBuildRequest(
+        track_id=track,
+        as_of=dt.date(2026, 5, 27),
+        window_id="2026-05-27-open",
+        limit=limit,
+    )
+
+
+# --------------------------------------------------------------------------
+# Acceptance: 50+ candidates per enabled "broad" track
+# --------------------------------------------------------------------------
+@pytest.mark.parametrize("track", ("aggressive", "yolo", "quant_signal"))
+def test_universe_builder_admits_at_least_50_per_broad_track(
+    builder: UniverseBuilder, track: str,
+) -> None:
+    result = builder.build(_request(track))
+    assert len(result.candidates) >= 50, (
+        f"{track} only got {len(result.candidates)} candidates; "
+        f"diagnostics={result.diagnostics}"
+    )
+
+
+def test_universe_builder_admits_enough_per_conservative(
+    builder: UniverseBuilder,
+) -> None:
+    # Conservative is intentionally restrictive (mega+large only, $25M ADV
+    # floor) — we just require something non-trivial to come through.
+    result = builder.build(_request("conservative"))
+    assert len(result.candidates) >= 5
+    for cand in result.candidates:
+        # No micro/nano caps allowed.
+        assert any(
+            r.code == CandidateReasonCode.IN_MARKET_CAP_BAND
+            and r.params.get("band") in {"mega", "large"}
+            for r in cand.reasons
+        )
+
+
+def test_every_candidate_carries_typed_reasons(builder: UniverseBuilder) -> None:
+    result = builder.build(_request("aggressive"))
+    assert result.candidates
+    for cand in result.candidates:
+        codes = {r.code for r in cand.reasons}
+        assert CandidateReasonCode.INSTRUMENT_ALLOWED in codes
+        assert CandidateReasonCode.PASSES_ADV_FLOOR in codes
+        assert CandidateReasonCode.PASSES_PRICE_FLOOR in codes
+        assert CandidateReasonCode.IN_MARKET_CAP_BAND in codes
+
+
+def test_yolo_unlocks_low_visibility_bucket(builder: UniverseBuilder) -> None:
+    result = builder.build(_request("yolo"))
+    hidden = [c for c in result.candidates if c.bucket == "hidden_gem"]
+    assert hidden, "YOLO should surface at least one hidden-gem candidate"
+    for cand in hidden:
+        codes = {r.code for r in cand.reasons}
+        assert CandidateReasonCode.LOW_VISIBILITY in codes
+        assert CandidateReasonCode.HIDDEN_GEM_BUCKET in codes
+
+
+def test_conservative_never_returns_hidden_gem(builder: UniverseBuilder) -> None:
+    result = builder.build(_request("conservative"))
+    assert all(c.bucket == "core" for c in result.candidates)
+
+
+def test_unknown_track_raises_key_error(builder: UniverseBuilder) -> None:
+    with pytest.raises(KeyError):
+        builder.build(_request("not_a_real_track"))
+
+
+def test_build_is_deterministic_for_same_inputs(builder: UniverseBuilder) -> None:
+    a = builder.build(_request("aggressive"))
+    b = builder.build(_request("aggressive"))
+    assert tuple(c.symbol for c in a.candidates) == tuple(c.symbol for c in b.candidates)
+
+
+def test_default_universe_policies_cover_all_phase1_tracks() -> None:
+    from stockripper.tracks import DEFAULT_TRACKS
+
+    for spec in DEFAULT_TRACKS:
+        assert spec.track_id in DEFAULT_UNIVERSE_POLICIES, (
+            f"track {spec.track_id} is missing a universe policy"
+        )

--- a/tests/test_data_universe_policy.py
+++ b/tests/test_data_universe_policy.py
@@ -1,0 +1,36 @@
+"""Tests for :class:`MarketCapBand.classify`."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from stockripper.data.universe_policy import MarketCapBand
+
+
+@pytest.mark.parametrize(
+    ("cap_usd", "expected"),
+    [
+        (Decimal("250000000000"), MarketCapBand.MEGA),
+        (Decimal("200000000001"), MarketCapBand.MEGA),
+        (Decimal("199999999999"), MarketCapBand.LARGE),
+        (Decimal("10000000001"), MarketCapBand.LARGE),
+        (Decimal("9999999999"), MarketCapBand.MID),
+        (Decimal("2000000001"), MarketCapBand.MID),
+        (Decimal("1999999999"), MarketCapBand.SMALL),
+        (Decimal("300000001"), MarketCapBand.SMALL),
+        (Decimal("299999999"), MarketCapBand.MICRO),
+        (Decimal("50000001"), MarketCapBand.MICRO),
+        (Decimal("49999999"), MarketCapBand.NANO),
+        (Decimal("1"), MarketCapBand.NANO),
+    ],
+)
+def test_classify_boundaries(cap_usd: Decimal, expected: MarketCapBand) -> None:
+    assert MarketCapBand.classify(cap_usd) is expected
+
+
+def test_classify_none_for_zero_or_negative() -> None:
+    assert MarketCapBand.classify(None) is None
+    assert MarketCapBand.classify(Decimal("0")) is None
+    assert MarketCapBand.classify(Decimal("-1")) is None

--- a/tests/test_no_order_surface.py
+++ b/tests/test_no_order_surface.py
@@ -1,0 +1,73 @@
+"""Structural ban: nothing under ``stockripper.data`` may import order-capable Alpaca surfaces.
+
+Order submission/cancellation is a Phase 5 concern in
+``stockripper.execution`` (not yet written). Phase 2 research code must not
+even *import* the symbols that submit orders, so an accidental import is
+caught at lint time rather than at runtime.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+# Anything in this set, imported anywhere under stockripper.data, is a bug.
+_BANNED_NAMES = frozenset(
+    {
+        "OrderRequest",
+        "MarketOrderRequest",
+        "LimitOrderRequest",
+        "StopOrderRequest",
+        "StopLimitOrderRequest",
+        "TrailingStopOrderRequest",
+        "GetOptionContractsRequest",  # not an order but options-trading entry
+        "ReplaceOrderRequest",
+        "ClosePositionRequest",
+    }
+)
+
+_BANNED_MODULES = frozenset(
+    {
+        "alpaca.broker.client",
+    }
+)
+
+# ``alpaca.trading.client.TradingClient`` itself is allowed — but ONLY in the
+# integrations factory module, which exposes it under a read-only Protocol.
+_TRADING_CLIENT_ALLOWED_PATHS = (
+    Path("src") / "stockripper" / "integrations" / "alpaca" / "__init__.py",
+    Path("src") / "stockripper" / "data" / "live.py",
+)
+
+
+def _iter_data_python_files() -> list[Path]:
+    repo = Path(__file__).resolve().parents[1]
+    root = repo / "src" / "stockripper" / "data"
+    return sorted(p for p in root.rglob("*.py"))
+
+
+@pytest.mark.parametrize("path", _iter_data_python_files(), ids=lambda p: p.name)
+def test_no_order_surface_import(path: Path) -> None:
+    tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module in _BANNED_MODULES:
+                pytest.fail(f"{path} imports banned module {module}")
+            if module == "alpaca.trading.client":
+                rel = path.relative_to(Path(__file__).resolve().parents[1])
+                assert rel in _TRADING_CLIENT_ALLOWED_PATHS, (
+                    f"{path} imports alpaca.trading.client (order-capable); "
+                    "only the integrations factory or live wiring may do that."
+                )
+            for alias in node.names:
+                if alias.name in _BANNED_NAMES:
+                    pytest.fail(
+                        f"{path} imports banned name {alias.name} from {module}"
+                    )
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name in _BANNED_MODULES:
+                    pytest.fail(f"{path} imports banned module {alias.name}")

--- a/uv.lock
+++ b/uv.lock
@@ -2,8 +2,15 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.15'",
-    "python_full_version < '3.15'",
+    "python_full_version >= '3.15' and sys_platform == 'win32'",
+    "python_full_version >= '3.15' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.15' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'win32'",
+    "python_full_version == '3.14.*' and sys_platform == 'emscripten'",
+    "python_full_version == '3.14.*' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -18,6 +25,24 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
+name = "alpaca-py"
+version = "0.43.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "msgpack" },
+    { name = "pandas" },
+    { name = "pydantic" },
+    { name = "pytz" },
+    { name = "requests" },
+    { name = "sseclient-py" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/9d/3003f661c15b8003655c447c187aec10f0843647e5c98b391701b04ac3d8/alpaca_py-0.43.4.tar.gz", hash = "sha256:7d529b3654d4e817d9fd7ab461131c4f06a315c736b6a9e4a87d5406bb71114a", size = 97990, upload-time = "2026-04-29T08:41:48.775Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3a/d5/1f57cc03e7b5925a927cb7f8e7ee5f873e22632633778d28d5d23681c871/alpaca_py-0.43.4-py3-none-any.whl", hash = "sha256:dd49ac30e0f2a8f38550ef1f27a58e7fd8f3f3875deaa4e757443cdbd033a1b4", size = 122534, upload-time = "2026-04-29T08:41:50.149Z" },
 ]
 
 [[package]]
@@ -164,6 +189,79 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/1d/ec1a60bd1a10daa292d3cd6bb0b359a81607154fb8165f3ec95fe003b85c/cffi-2.0.0-cp314-cp314t-win32.whl", hash = "sha256:1fc9ea04857caf665289b7a75923f2c6ed559b8298a1b8c49e59f7dd95c8481e", size = 180487, upload-time = "2025-09-08T23:23:40.423Z" },
     { url = "https://files.pythonhosted.org/packages/bf/41/4c1168c74fac325c0c8156f04b6749c8b6a8f405bbf91413ba088359f60d/cffi-2.0.0-cp314-cp314t-win_amd64.whl", hash = "sha256:d68b6cef7827e8641e8ef16f4494edda8b36104d79773a334beaa1e3521430f6", size = 191726, upload-time = "2025-09-08T23:23:41.742Z" },
     { url = "https://files.pythonhosted.org/packages/ae/3a/dbeec9d1ee0844c679f6bb5d6ad4e9f198b1224f4e7a32825f47f6192b0c/cffi-2.0.0-cp314-cp314t-win_arm64.whl", hash = "sha256:0a1527a803f0a659de1af2e1fd700213caba79377e27e4693648c2923da066f9", size = 184195, upload-time = "2025-09-08T23:23:43.004Z" },
+]
+
+[[package]]
+name = "charset-normalizer"
+version = "3.4.7"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/a1/67fe25fac3c7642725500a3f6cfe5821ad557c3abb11c9d20d12c7008d3e/charset_normalizer-3.4.7.tar.gz", hash = "sha256:ae89db9e5f98a11a4bf50407d4363e7b09b31e55bc117b4f7d80aab97ba009e5", size = 144271, upload-time = "2026-04-02T09:28:39.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/eb/4fc8d0a7110eb5fc9cc161723a34a8a6c200ce3b4fbf681bc86feee22308/charset_normalizer-3.4.7-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:eca9705049ad3c7345d574e3510665cb2cf844c2f2dcfe675332677f081cbd46", size = 311328, upload-time = "2026-04-02T09:26:24.331Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/e3/0fadc706008ac9d7b9b5be6dc767c05f9d3e5df51744ce4cc9605de7b9f4/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6178f72c5508bfc5fd446a5905e698c6212932f25bcdd4b47a757a50605a90e2", size = 208061, upload-time = "2026-04-02T09:26:25.568Z" },
+    { url = "https://files.pythonhosted.org/packages/42/f0/3dd1045c47f4a4604df85ec18ad093912ae1344ac706993aff91d38773a2/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:e1421b502d83040e6d7fb2fb18dff63957f720da3d77b2fbd3187ceb63755d7b", size = 229031, upload-time = "2026-04-02T09:26:26.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/67/675a46eb016118a2fbde5a277a5d15f4f69d5f3f5f338e5ee2f8948fcf43/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:edac0f1ab77644605be2cbba52e6b7f630731fc42b34cb0f634be1a6eface56a", size = 225239, upload-time = "2026-04-02T09:26:28.044Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/f8/d0118a2f5f23b02cd166fa385c60f9b0d4f9194f574e2b31cef350ad7223/charset_normalizer-3.4.7-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5649fd1c7bade02f320a462fdefd0b4bd3ce036065836d4f42e0de958038e116", size = 216589, upload-time = "2026-04-02T09:26:29.239Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/f1/6d2b0b261b6c4ceef0fcb0d17a01cc5bc53586c2d4796fa04b5c540bc13d/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_armv7l.whl", hash = "sha256:203104ed3e428044fd943bc4bf45fa73c0730391f9621e37fe39ecf477b128cb", size = 202733, upload-time = "2026-04-02T09:26:30.5Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/c0/7b1f943f7e87cc3db9626ba17807d042c38645f0a1d4415c7a14afb5591f/charset_normalizer-3.4.7-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:298930cec56029e05497a76988377cbd7457ba864beeea92ad7e844fe74cd1f1", size = 212652, upload-time = "2026-04-02T09:26:31.709Z" },
+    { url = "https://files.pythonhosted.org/packages/38/dd/5a9ab159fe45c6e72079398f277b7d2b523e7f716acc489726115a910097/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:708838739abf24b2ceb208d0e22403dd018faeef86ddac04319a62ae884c4f15", size = 211229, upload-time = "2026-04-02T09:26:33.282Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/ff/531a1cad5ca855d1c1a8b69cb71abfd6d85c0291580146fda7c82857caa1/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_armv7l.whl", hash = "sha256:0f7eb884681e3938906ed0434f20c63046eacd0111c4ba96f27b76084cd679f5", size = 203552, upload-time = "2026-04-02T09:26:34.845Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/4c/a5fb52d528a8ca41f7598cb619409ece30a169fbdf9cdce592e53b46c3a6/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:4dc1e73c36828f982bfe79fadf5919923f8a6f4df2860804db9a98c48824ce8d", size = 230806, upload-time = "2026-04-02T09:26:36.152Z" },
+    { url = "https://files.pythonhosted.org/packages/59/7a/071feed8124111a32b316b33ae4de83d36923039ef8cf48120266844285b/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:aed52fea0513bac0ccde438c188c8a471c4e0f457c2dd20cdbf6ea7a450046c7", size = 212316, upload-time = "2026-04-02T09:26:37.672Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/35/f7dba3994312d7ba508e041eaac39a36b120f32d4c8662b8814dab876431/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:fea24543955a6a729c45a73fe90e08c743f0b3334bbf3201e6c4bc1b0c7fa464", size = 227274, upload-time = "2026-04-02T09:26:38.93Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/2d/a572df5c9204ab7688ec1edc895a73ebded3b023bb07364710b05dd1c9be/charset_normalizer-3.4.7-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bb6d88045545b26da47aa879dd4a89a71d1dce0f0e549b1abcb31dfe4a8eac49", size = 218468, upload-time = "2026-04-02T09:26:40.17Z" },
+    { url = "https://files.pythonhosted.org/packages/86/eb/890922a8b03a568ca2f336c36585a4713c55d4d67bf0f0c78924be6315ca/charset_normalizer-3.4.7-cp312-cp312-win32.whl", hash = "sha256:2257141f39fe65a3fdf38aeccae4b953e5f3b3324f4ff0daf9f15b8518666a2c", size = 148460, upload-time = "2026-04-02T09:26:41.416Z" },
+    { url = "https://files.pythonhosted.org/packages/35/d9/0e7dffa06c5ab081f75b1b786f0aefc88365825dfcd0ac544bdb7b2b6853/charset_normalizer-3.4.7-cp312-cp312-win_amd64.whl", hash = "sha256:5ed6ab538499c8644b8a3e18debabcd7ce684f3fa91cf867521a7a0279cab2d6", size = 159330, upload-time = "2026-04-02T09:26:42.554Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5d/481bcc2a7c88ea6b0878c299547843b2521ccbc40980cb406267088bc701/charset_normalizer-3.4.7-cp312-cp312-win_arm64.whl", hash = "sha256:56be790f86bfb2c98fb742ce566dfb4816e5a83384616ab59c49e0604d49c51d", size = 147828, upload-time = "2026-04-02T09:26:44.075Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/3b/66777e39d3ae1ddc77ee606be4ec6d8cbd4c801f65e5a1b6f2b11b8346dd/charset_normalizer-3.4.7-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:f496c9c3cc02230093d8330875c4c3cdfc3b73612a5fd921c65d39cbcef08063", size = 309627, upload-time = "2026-04-02T09:26:45.198Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/4e/b7f84e617b4854ade48a1b7915c8ccfadeba444d2a18c291f696e37f0d3b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0ea948db76d31190bf08bd371623927ee1339d5f2a0b4b1b4a4439a65298703c", size = 207008, upload-time = "2026-04-02T09:26:46.824Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/bb/ec73c0257c9e11b268f018f068f5d00aa0ef8c8b09f7753ebd5f2880e248/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a277ab8928b9f299723bc1a2dabb1265911b1a76341f90a510368ca44ad9ab66", size = 228303, upload-time = "2026-04-02T09:26:48.397Z" },
+    { url = "https://files.pythonhosted.org/packages/85/fb/32d1f5033484494619f701e719429c69b766bfc4dbc61aa9e9c8c166528b/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:3bec022aec2c514d9cf199522a802bd007cd588ab17ab2525f20f9c34d067c18", size = 224282, upload-time = "2026-04-02T09:26:49.684Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/07/330e3a0dda4c404d6da83b327270906e9654a24f6c546dc886a0eb0ffb23/charset_normalizer-3.4.7-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e044c39e41b92c845bc815e5ae4230804e8e7bc29e399b0437d64222d92809dd", size = 215595, upload-time = "2026-04-02T09:26:50.915Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/7c/fc890655786e423f02556e0216d4b8c6bcb6bdfa890160dc66bf52dee468/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_armv7l.whl", hash = "sha256:f495a1652cf3fbab2eb0639776dad966c2fb874d79d87ca07f9d5f059b8bd215", size = 201986, upload-time = "2026-04-02T09:26:52.197Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/97/bfb18b3db2aed3b90cf54dc292ad79fdd5ad65c4eae454099475cbeadd0d/charset_normalizer-3.4.7-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e712b419df8ba5e42b226c510472b37bd57b38e897d3eca5e8cfd410a29fa859", size = 211711, upload-time = "2026-04-02T09:26:53.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/a5/a581c13798546a7fd557c82614a5c65a13df2157e9ad6373166d2a3e645d/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:7804338df6fcc08105c7745f1502ba68d900f45fd770d5bdd5288ddccb8a42d8", size = 210036, upload-time = "2026-04-02T09:26:54.975Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/bf/b3ab5bcb478e4193d517644b0fb2bf5497fbceeaa7a1bc0f4d5b50953861/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_armv7l.whl", hash = "sha256:481551899c856c704d58119b5025793fa6730adda3571971af568f66d2424bb5", size = 202998, upload-time = "2026-04-02T09:26:56.303Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/4e/23efd79b65d314fa320ec6017b4b5834d5c12a58ba4610aa353af2e2f577/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:f59099f9b66f0d7145115e6f80dd8b1d847176df89b234a5a6b3f00437aa0832", size = 230056, upload-time = "2026-04-02T09:26:57.554Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/9f/1e1941bc3f0e01df116e68dc37a55c4d249df5e6fa77f008841aef68264f/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:f59ad4c0e8f6bba240a9bb85504faa1ab438237199d4cce5f622761507b8f6a6", size = 211537, upload-time = "2026-04-02T09:26:58.843Z" },
+    { url = "https://files.pythonhosted.org/packages/80/0f/088cbb3020d44428964a6c97fe1edfb1b9550396bf6d278330281e8b709c/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:3dedcc22d73ec993f42055eff4fcfed9318d1eeb9a6606c55892a26964964e48", size = 226176, upload-time = "2026-04-02T09:27:00.437Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/9f/130394f9bbe06f4f63e22641d32fc9b202b7e251c9aef4db044324dac493/charset_normalizer-3.4.7-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:64f02c6841d7d83f832cd97ccf8eb8a906d06eb95d5276069175c696b024b60a", size = 217723, upload-time = "2026-04-02T09:27:02.021Z" },
+    { url = "https://files.pythonhosted.org/packages/73/55/c469897448a06e49f8fa03f6caae97074fde823f432a98f979cc42b90e69/charset_normalizer-3.4.7-cp313-cp313-win32.whl", hash = "sha256:4042d5c8f957e15221d423ba781e85d553722fc4113f523f2feb7b188cc34c5e", size = 148085, upload-time = "2026-04-02T09:27:03.192Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/78/1b74c5bbb3f99b77a1715c91b3e0b5bdb6fe302d95ace4f5b1bec37b0167/charset_normalizer-3.4.7-cp313-cp313-win_amd64.whl", hash = "sha256:3946fa46a0cf3e4c8cb1cc52f56bb536310d34f25f01ca9b6c16afa767dab110", size = 158819, upload-time = "2026-04-02T09:27:04.454Z" },
+    { url = "https://files.pythonhosted.org/packages/68/86/46bd42279d323deb8687c4a5a811fd548cb7d1de10cf6535d099877a9a9f/charset_normalizer-3.4.7-cp313-cp313-win_arm64.whl", hash = "sha256:80d04837f55fc81da168b98de4f4b797ef007fc8a79ab71c6ec9bc4dd662b15b", size = 147915, upload-time = "2026-04-02T09:27:05.971Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c8/c67cb8c70e19ef1960b97b22ed2a1567711de46c4ddf19799923adc836c2/charset_normalizer-3.4.7-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:c36c333c39be2dbca264d7803333c896ab8fa7d4d6f0ab7edb7dfd7aea6e98c0", size = 309234, upload-time = "2026-04-02T09:27:07.194Z" },
+    { url = "https://files.pythonhosted.org/packages/99/85/c091fdee33f20de70d6c8b522743b6f831a2f1cd3ff86de4c6a827c48a76/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1c2aed2e5e41f24ea8ef1590b8e848a79b56f3a5564a65ceec43c9d692dc7d8a", size = 208042, upload-time = "2026-04-02T09:27:08.749Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/ab2ce611b984d2fd5d86a5a8a19c1ae26acac6bad967da4967562c75114d/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:54523e136b8948060c0fa0bc7b1b50c32c186f2fceee897a495406bb6e311d2b", size = 228706, upload-time = "2026-04-02T09:27:09.951Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/29/2b1d2cb00bf085f59d29eb773ce58ec2d325430f8c216804a0a5cd83cbca/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:715479b9a2802ecac752a3b0efa2b0b60285cf962ee38414211abdfccc233b41", size = 224727, upload-time = "2026-04-02T09:27:11.175Z" },
+    { url = "https://files.pythonhosted.org/packages/47/5c/032c2d5a07fe4d4855fea851209cca2b6f03ebeb6d4e3afdb3358386a684/charset_normalizer-3.4.7-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bd6c2a1c7573c64738d716488d2cdd3c00e340e4835707d8fdb8dc1a66ef164e", size = 215882, upload-time = "2026-04-02T09:27:12.446Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c2/356065d5a8b78ed04499cae5f339f091946a6a74f91e03476c33f0ab7100/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_armv7l.whl", hash = "sha256:c45e9440fb78f8ddabcf714b68f936737a121355bf59f3907f4e17721b9d1aae", size = 200860, upload-time = "2026-04-02T09:27:13.721Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/cd/a32a84217ced5039f53b29f460962abb2d4420def55afabe45b1c3c7483d/charset_normalizer-3.4.7-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3534e7dcbdcf757da6b85a0bbf5b6868786d5982dd959b065e65481644817a18", size = 211564, upload-time = "2026-04-02T09:27:15.272Z" },
+    { url = "https://files.pythonhosted.org/packages/44/86/58e6f13ce26cc3b8f4a36b94a0f22ae2f00a72534520f4ae6857c4b81f89/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e8ac484bf18ce6975760921bb6148041faa8fef0547200386ea0b52b5d27bf7b", size = 211276, upload-time = "2026-04-02T09:27:16.834Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/fe/d17c32dc72e17e155e06883efa84514ca375f8a528ba2546bee73fc4df81/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_armv7l.whl", hash = "sha256:a5fe03b42827c13cdccd08e6c0247b6a6d4b5e3cdc53fd1749f5896adcdc2356", size = 201238, upload-time = "2026-04-02T09:27:18.229Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/29/f33daa50b06525a237451cdb6c69da366c381a3dadcd833fa5676bc468b3/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:2d6eb928e13016cea4f1f21d1e10c1cebd5a421bc57ddf5b1142ae3f86824fab", size = 230189, upload-time = "2026-04-02T09:27:19.445Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/6e/52c84015394a6a0bdcd435210a7e944c5f94ea1055f5cc5d56c5fe368e7b/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:e74327fb75de8986940def6e8dee4f127cc9752bee7355bb323cc5b2659b6d46", size = 211352, upload-time = "2026-04-02T09:27:20.79Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d7/4353be581b373033fb9198bf1da3cf8f09c1082561e8e922aa7b39bf9fe8/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:d6038d37043bced98a66e68d3aa2b6a35505dc01328cd65217cefe82f25def44", size = 227024, upload-time = "2026-04-02T09:27:22.063Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/99d18aa925bd1740098ccd3060e238e21115fffbfdcb8f3ece837d0ace6c/charset_normalizer-3.4.7-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:7579e913a5339fb8fa133f6bbcfd8e6749696206cf05acdbdca71a1b436d8e72", size = 217869, upload-time = "2026-04-02T09:27:23.486Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/05/5ee478aa53f4bb7996482153d4bfe1b89e0f087f0ab6b294fcf92d595873/charset_normalizer-3.4.7-cp314-cp314-win32.whl", hash = "sha256:5b77459df20e08151cd6f8b9ef8ef1f961ef73d85c21a555c7eed5b79410ec10", size = 148541, upload-time = "2026-04-02T09:27:25.146Z" },
+    { url = "https://files.pythonhosted.org/packages/48/77/72dcb0921b2ce86420b2d79d454c7022bf5be40202a2a07906b9f2a35c97/charset_normalizer-3.4.7-cp314-cp314-win_amd64.whl", hash = "sha256:92a0a01ead5e668468e952e4238cccd7c537364eb7d851ab144ab6627dbbe12f", size = 159634, upload-time = "2026-04-02T09:27:26.642Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/a3/c2369911cd72f02386e4e340770f6e158c7980267da16af8f668217abaa0/charset_normalizer-3.4.7-cp314-cp314-win_arm64.whl", hash = "sha256:67f6279d125ca0046a7fd386d01b311c6363844deac3e5b069b514ba3e63c246", size = 148384, upload-time = "2026-04-02T09:27:28.271Z" },
+    { url = "https://files.pythonhosted.org/packages/94/09/7e8a7f73d24dba1f0035fbbf014d2c36828fc1bf9c88f84093e57d315935/charset_normalizer-3.4.7-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:effc3f449787117233702311a1b7d8f59cba9ced946ba727bdc329ec69028e24", size = 330133, upload-time = "2026-04-02T09:27:29.474Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/da/96975ddb11f8e977f706f45cddd8540fd8242f71ecdb5d18a80723dcf62c/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fbccdc05410c9ee21bbf16a35f4c1d16123dcdeb8a1d38f33654fa21d0234f79", size = 216257, upload-time = "2026-04-02T09:27:30.793Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/e8/1d63bf8ef2d388e95c64b2098f45f84758f6d102a087552da1485912637b/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:733784b6d6def852c814bce5f318d25da2ee65dd4839a0718641c696e09a2960", size = 234851, upload-time = "2026-04-02T09:27:32.44Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/40/e5ff04233e70da2681fa43969ad6f66ca5611d7e669be0246c4c7aaf6dc8/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a89c23ef8d2c6b27fd200a42aa4ac72786e7c60d40efdc76e6011260b6e949c4", size = 233393, upload-time = "2026-04-02T09:27:34.03Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c1/06c6c49d5a5450f76899992f1ee40b41d076aee9279b49cf9974d2f313d5/charset_normalizer-3.4.7-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6c114670c45346afedc0d947faf3c7f701051d2518b943679c8ff88befe14f8e", size = 223251, upload-time = "2026-04-02T09:27:35.369Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/9f/f2ff16fb050946169e3e1f82134d107e5d4ae72647ec8a1b1446c148480f/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_armv7l.whl", hash = "sha256:a180c5e59792af262bf263b21a3c49353f25945d8d9f70628e73de370d55e1e1", size = 206609, upload-time = "2026-04-02T09:27:36.661Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d5/a527c0cd8d64d2eab7459784fb4169a0ac76e5a6fc5237337982fd61347e/charset_normalizer-3.4.7-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:3c9a494bc5ec77d43cea229c4f6db1e4d8fe7e1bbffa8b6f0f0032430ff8ab44", size = 220014, upload-time = "2026-04-02T09:27:38.019Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/80/8a7b8104a3e203074dc9aa2c613d4b726c0e136bad1cc734594b02867972/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8d828b6667a32a728a1ad1d93957cdf37489c57b97ae6c4de2860fa749b8fc1e", size = 218979, upload-time = "2026-04-02T09:27:39.37Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9a/b759b503d507f375b2b5c153e4d2ee0a75aa215b7f2489cf314f4541f2c0/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_armv7l.whl", hash = "sha256:cf1493cd8607bec4d8a7b9b004e699fcf8f9103a9284cc94962cb73d20f9d4a3", size = 209238, upload-time = "2026-04-02T09:27:40.722Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/4e/0f3f5d47b86bdb79256e7290b26ac847a2832d9a4033f7eb2cd4bcf4bb5b/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:0c96c3b819b5c3e9e165495db84d41914d6894d55181d2d108cc1a69bfc9cce0", size = 236110, upload-time = "2026-04-02T09:27:42.33Z" },
+    { url = "https://files.pythonhosted.org/packages/96/23/bce28734eb3ed2c91dcf93abeb8a5cf393a7b2749725030bb630e554fdd8/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:752a45dc4a6934060b3b0dab47e04edc3326575f82be64bc4fc293914566503e", size = 219824, upload-time = "2026-04-02T09:27:43.924Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/6f/6e897c6984cc4d41af319b077f2f600fc8214eb2fe2d6bcb79141b882400/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:8778f0c7a52e56f75d12dae53ae320fae900a8b9b4164b981b9c5ce059cd1fcb", size = 233103, upload-time = "2026-04-02T09:27:45.348Z" },
+    { url = "https://files.pythonhosted.org/packages/76/22/ef7bd0fe480a0ae9b656189ec00744b60933f68b4f42a7bb06589f6f576a/charset_normalizer-3.4.7-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:ce3412fbe1e31eb81ea42f4169ed94861c56e643189e1e75f0041f3fe7020abe", size = 225194, upload-time = "2026-04-02T09:27:46.706Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/a7/0e0ab3e0b5bc1219bd80a6a0d4d72ca74d9250cb2382b7c699c147e06017/charset_normalizer-3.4.7-cp314-cp314t-win32.whl", hash = "sha256:c03a41a8784091e67a39648f70c5f97b5b6a37f216896d44d2cdcb82615339a0", size = 159827, upload-time = "2026-04-02T09:27:48.053Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1d/29d32e0fb40864b1f878c7f5a0b343ae676c6e2b271a2d55cc3a152391da/charset_normalizer-3.4.7-cp314-cp314t-win_amd64.whl", hash = "sha256:03853ed82eeebbce3c2abfdbc98c96dc205f32a79627688ac9a27370ea61a49c", size = 174168, upload-time = "2026-04-02T09:27:49.795Z" },
+    { url = "https://files.pythonhosted.org/packages/de/32/d92444ad05c7a6e41fb2036749777c163baf7a0301a040cb672d6b2b1ae9/charset_normalizer-3.4.7-cp314-cp314t-win_arm64.whl", hash = "sha256:c35abb8bfff0185efac5878da64c45dafd2b37fb0383add1be155a763c1f083d", size = 153018, upload-time = "2026-04-02T09:27:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/61959034484a4a7c527811f4721e75d02d653a35afb0b6054474d8185d4c/charset_normalizer-3.4.7-py3-none-any.whl", hash = "sha256:3dce51d0f5e7951f8bb4900c257dad282f49190fdbebecd4ba99bcc41fef404d", size = 61958, upload-time = "2026-04-02T09:28:37.794Z" },
 ]
 
 [[package]]
@@ -733,6 +831,50 @@ wheels = [
 ]
 
 [[package]]
+name = "msgpack"
+version = "1.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/f2/bfb55a6236ed8725a96b0aa3acbd0ec17588e6a2c3b62a93eb513ed8783f/msgpack-1.1.2.tar.gz", hash = "sha256:3b60763c1373dd60f398488069bcdc703cd08a711477b5d480eecc9f9626f47e", size = 173581, upload-time = "2025-10-08T09:15:56.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ad/bd/8b0d01c756203fbab65d265859749860682ccd2a59594609aeec3a144efa/msgpack-1.1.2-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:70a0dff9d1f8da25179ffcf880e10cf1aad55fdb63cd59c9a49a1b82290062aa", size = 81939, upload-time = "2025-10-08T09:15:01.472Z" },
+    { url = "https://files.pythonhosted.org/packages/34/68/ba4f155f793a74c1483d4bdef136e1023f7bcba557f0db4ef3db3c665cf1/msgpack-1.1.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:446abdd8b94b55c800ac34b102dffd2f6aa0ce643c55dfc017ad89347db3dbdb", size = 85064, upload-time = "2025-10-08T09:15:03.764Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/60/a064b0345fc36c4c3d2c743c82d9100c40388d77f0b48b2f04d6041dbec1/msgpack-1.1.2-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c63eea553c69ab05b6747901b97d620bb2a690633c77f23feb0c6a947a8a7b8f", size = 417131, upload-time = "2025-10-08T09:15:05.136Z" },
+    { url = "https://files.pythonhosted.org/packages/65/92/a5100f7185a800a5d29f8d14041f61475b9de465ffcc0f3b9fba606e4505/msgpack-1.1.2-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:372839311ccf6bdaf39b00b61288e0557916c3729529b301c52c2d88842add42", size = 427556, upload-time = "2025-10-08T09:15:06.837Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/87/ffe21d1bf7d9991354ad93949286f643b2bb6ddbeab66373922b44c3b8cc/msgpack-1.1.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:2929af52106ca73fcb28576218476ffbb531a036c2adbcf54a3664de124303e9", size = 404920, upload-time = "2025-10-08T09:15:08.179Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/41/8543ed2b8604f7c0d89ce066f42007faac1eaa7d79a81555f206a5cdb889/msgpack-1.1.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:be52a8fc79e45b0364210eef5234a7cf8d330836d0a64dfbb878efa903d84620", size = 415013, upload-time = "2025-10-08T09:15:09.83Z" },
+    { url = "https://files.pythonhosted.org/packages/41/0d/2ddfaa8b7e1cee6c490d46cb0a39742b19e2481600a7a0e96537e9c22f43/msgpack-1.1.2-cp312-cp312-win32.whl", hash = "sha256:1fff3d825d7859ac888b0fbda39a42d59193543920eda9d9bea44d958a878029", size = 65096, upload-time = "2025-10-08T09:15:11.11Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/ec/d431eb7941fb55a31dd6ca3404d41fbb52d99172df2e7707754488390910/msgpack-1.1.2-cp312-cp312-win_amd64.whl", hash = "sha256:1de460f0403172cff81169a30b9a92b260cb809c4cb7e2fc79ae8d0510c78b6b", size = 72708, upload-time = "2025-10-08T09:15:12.554Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/31/5b1a1f70eb0e87d1678e9624908f86317787b536060641d6798e3cf70ace/msgpack-1.1.2-cp312-cp312-win_arm64.whl", hash = "sha256:be5980f3ee0e6bd44f3a9e9dea01054f175b50c3e6cdb692bc9424c0bbb8bf69", size = 64119, upload-time = "2025-10-08T09:15:13.589Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/31/b46518ecc604d7edf3a4f94cb3bf021fc62aa301f0cb849936968164ef23/msgpack-1.1.2-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:4efd7b5979ccb539c221a4c4e16aac1a533efc97f3b759bb5a5ac9f6d10383bf", size = 81212, upload-time = "2025-10-08T09:15:14.552Z" },
+    { url = "https://files.pythonhosted.org/packages/92/dc/c385f38f2c2433333345a82926c6bfa5ecfff3ef787201614317b58dd8be/msgpack-1.1.2-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:42eefe2c3e2af97ed470eec850facbe1b5ad1d6eacdbadc42ec98e7dcf68b4b7", size = 84315, upload-time = "2025-10-08T09:15:15.543Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/68/93180dce57f684a61a88a45ed13047558ded2be46f03acb8dec6d7c513af/msgpack-1.1.2-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1fdf7d83102bf09e7ce3357de96c59b627395352a4024f6e2458501f158bf999", size = 412721, upload-time = "2025-10-08T09:15:16.567Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/ba/459f18c16f2b3fc1a1ca871f72f07d70c07bf768ad0a507a698b8052ac58/msgpack-1.1.2-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fac4be746328f90caa3cd4bc67e6fe36ca2bf61d5c6eb6d895b6527e3f05071e", size = 424657, upload-time = "2025-10-08T09:15:17.825Z" },
+    { url = "https://files.pythonhosted.org/packages/38/f8/4398c46863b093252fe67368b44edc6c13b17f4e6b0e4929dbf0bdb13f23/msgpack-1.1.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:fffee09044073e69f2bad787071aeec727183e7580443dfeb8556cbf1978d162", size = 402668, upload-time = "2025-10-08T09:15:19.003Z" },
+    { url = "https://files.pythonhosted.org/packages/28/ce/698c1eff75626e4124b4d78e21cca0b4cc90043afb80a507626ea354ab52/msgpack-1.1.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:5928604de9b032bc17f5099496417f113c45bc6bc21b5c6920caf34b3c428794", size = 419040, upload-time = "2025-10-08T09:15:20.183Z" },
+    { url = "https://files.pythonhosted.org/packages/67/32/f3cd1667028424fa7001d82e10ee35386eea1408b93d399b09fb0aa7875f/msgpack-1.1.2-cp313-cp313-win32.whl", hash = "sha256:a7787d353595c7c7e145e2331abf8b7ff1e6673a6b974ded96e6d4ec09f00c8c", size = 65037, upload-time = "2025-10-08T09:15:21.416Z" },
+    { url = "https://files.pythonhosted.org/packages/74/07/1ed8277f8653c40ebc65985180b007879f6a836c525b3885dcc6448ae6cb/msgpack-1.1.2-cp313-cp313-win_amd64.whl", hash = "sha256:a465f0dceb8e13a487e54c07d04ae3ba131c7c5b95e2612596eafde1dccf64a9", size = 72631, upload-time = "2025-10-08T09:15:22.431Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/db/0314e4e2db56ebcf450f277904ffd84a7988b9e5da8d0d61ab2d057df2b6/msgpack-1.1.2-cp313-cp313-win_arm64.whl", hash = "sha256:e69b39f8c0aa5ec24b57737ebee40be647035158f14ed4b40e6f150077e21a84", size = 64118, upload-time = "2025-10-08T09:15:23.402Z" },
+    { url = "https://files.pythonhosted.org/packages/22/71/201105712d0a2ff07b7873ed3c220292fb2ea5120603c00c4b634bcdafb3/msgpack-1.1.2-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:e23ce8d5f7aa6ea6d2a2b326b4ba46c985dbb204523759984430db7114f8aa00", size = 81127, upload-time = "2025-10-08T09:15:24.408Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/9f/38ff9e57a2eade7bf9dfee5eae17f39fc0e998658050279cbb14d97d36d9/msgpack-1.1.2-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:6c15b7d74c939ebe620dd8e559384be806204d73b4f9356320632d783d1f7939", size = 84981, upload-time = "2025-10-08T09:15:25.812Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/a9/3536e385167b88c2cc8f4424c49e28d49a6fc35206d4a8060f136e71f94c/msgpack-1.1.2-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:99e2cb7b9031568a2a5c73aa077180f93dd2e95b4f8d3b8e14a73ae94a9e667e", size = 411885, upload-time = "2025-10-08T09:15:27.22Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/40/dc34d1a8d5f1e51fc64640b62b191684da52ca469da9cd74e84936ffa4a6/msgpack-1.1.2-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:180759d89a057eab503cf62eeec0aa61c4ea1200dee709f3a8e9397dbb3b6931", size = 419658, upload-time = "2025-10-08T09:15:28.4Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/ef/2b92e286366500a09a67e03496ee8b8ba00562797a52f3c117aa2b29514b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:04fb995247a6e83830b62f0b07bf36540c213f6eac8e851166d8d86d83cbd014", size = 403290, upload-time = "2025-10-08T09:15:29.764Z" },
+    { url = "https://files.pythonhosted.org/packages/78/90/e0ea7990abea5764e4655b8177aa7c63cdfa89945b6e7641055800f6c16b/msgpack-1.1.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:8e22ab046fa7ede9e36eeb4cfad44d46450f37bb05d5ec482b02868f451c95e2", size = 415234, upload-time = "2025-10-08T09:15:31.022Z" },
+    { url = "https://files.pythonhosted.org/packages/72/4e/9390aed5db983a2310818cd7d3ec0aecad45e1f7007e0cda79c79507bb0d/msgpack-1.1.2-cp314-cp314-win32.whl", hash = "sha256:80a0ff7d4abf5fecb995fcf235d4064b9a9a8a40a3ab80999e6ac1e30b702717", size = 66391, upload-time = "2025-10-08T09:15:32.265Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/f1/abd09c2ae91228c5f3998dbd7f41353def9eac64253de3c8105efa2082f7/msgpack-1.1.2-cp314-cp314-win_amd64.whl", hash = "sha256:9ade919fac6a3e7260b7f64cea89df6bec59104987cbea34d34a2fa15d74310b", size = 73787, upload-time = "2025-10-08T09:15:33.219Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/b0/9d9f667ab48b16ad4115c1935d94023b82b3198064cb84a123e97f7466c1/msgpack-1.1.2-cp314-cp314-win_arm64.whl", hash = "sha256:59415c6076b1e30e563eb732e23b994a61c159cec44deaf584e5cc1dd662f2af", size = 66453, upload-time = "2025-10-08T09:15:34.225Z" },
+    { url = "https://files.pythonhosted.org/packages/16/67/93f80545eb1792b61a217fa7f06d5e5cb9e0055bed867f43e2b8e012e137/msgpack-1.1.2-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:897c478140877e5307760b0ea66e0932738879e7aa68144d9b78ea4c8302a84a", size = 85264, upload-time = "2025-10-08T09:15:35.61Z" },
+    { url = "https://files.pythonhosted.org/packages/87/1c/33c8a24959cf193966ef11a6f6a2995a65eb066bd681fd085afd519a57ce/msgpack-1.1.2-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:a668204fa43e6d02f89dbe79a30b0d67238d9ec4c5bd8a940fc3a004a47b721b", size = 89076, upload-time = "2025-10-08T09:15:36.619Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/6b/62e85ff7193663fbea5c0254ef32f0c77134b4059f8da89b958beb7696f3/msgpack-1.1.2-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5559d03930d3aa0f3aacb4c42c776af1a2ace2611871c84a75afe436695e6245", size = 435242, upload-time = "2025-10-08T09:15:37.647Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/47/5c74ecb4cc277cf09f64e913947871682ffa82b3b93c8dad68083112f412/msgpack-1.1.2-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:70c5a7a9fea7f036b716191c29047374c10721c389c21e9ffafad04df8c52c90", size = 432509, upload-time = "2025-10-08T09:15:38.794Z" },
+    { url = "https://files.pythonhosted.org/packages/24/a4/e98ccdb56dc4e98c929a3f150de1799831c0a800583cde9fa022fa90602d/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:f2cb069d8b981abc72b41aea1c580ce92d57c673ec61af4c500153a626cb9e20", size = 415957, upload-time = "2025-10-08T09:15:40.238Z" },
+    { url = "https://files.pythonhosted.org/packages/da/28/6951f7fb67bc0a4e184a6b38ab71a92d9ba58080b27a77d3e2fb0be5998f/msgpack-1.1.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:d62ce1f483f355f61adb5433ebfd8868c5f078d1a52d042b0a998682b4fa8c27", size = 422910, upload-time = "2025-10-08T09:15:41.505Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/03/42106dcded51f0a0b5284d3ce30a671e7bd3f7318d122b2ead66ad289fed/msgpack-1.1.2-cp314-cp314t-win32.whl", hash = "sha256:1d1418482b1ee984625d88aa9585db570180c286d942da463533b238b98b812b", size = 75197, upload-time = "2025-10-08T09:15:42.954Z" },
+    { url = "https://files.pythonhosted.org/packages/15/86/d0071e94987f8db59d4eeb386ddc64d0bb9b10820a8d82bcd3e53eeb2da6/msgpack-1.1.2-cp314-cp314t-win_amd64.whl", hash = "sha256:5a46bf7e831d09470ad92dff02b8b1ac92175ca36b087f904a0519857c6be3ff", size = 85772, upload-time = "2025-10-08T09:15:43.954Z" },
+    { url = "https://files.pythonhosted.org/packages/81/f2/08ace4142eb281c12701fc3b93a10795e4d4dc7f753911d836675050f886/msgpack-1.1.2-cp314-cp314t-win_arm64.whl", hash = "sha256:d99ef64f349d5ec3293688e91486c5fdb925ed03807f64d98d205d2713c60b46", size = 70868, upload-time = "2025-10-08T09:15:44.959Z" },
+]
+
+[[package]]
 name = "mypy"
 version = "2.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -786,6 +928,67 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy"
+version = "2.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
+    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
+    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
+    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
+    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
+    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
+    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
+    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
+    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
+    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
+    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
+    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
+    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/91/3ab2044d05fd16d343c5ac2e69b127f1b2854040dd20b193257c78028bd3/numpy-2.4.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:06ca2f61ec4385a07a6977c55ba998a4466c123642b4a32694d3128fce18c079", size = 16683458, upload-time = "2026-05-18T23:35:38.353Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/62/764ce66fa4147ae6d73071a3abf804ffe606f174618697c571acdf26a7c9/numpy-2.4.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:38efbc8de75c7a0fc1ac190162d892787f3f47b57cc291231aafee36b80982b7", size = 14704559, upload-time = "2026-05-18T23:35:42.14Z" },
+    { url = "https://files.pythonhosted.org/packages/60/61/23f27c172f022e04025b7dc2367f4d63c1a398120607ec896228649a6f48/numpy-2.4.6-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d581b735e177fdcdce6fed8e7e8880a3fb6ee4e3653a3ac6af01c6f4c03effc5", size = 5209716, upload-time = "2026-05-18T23:35:45.377Z" },
+    { url = "https://files.pythonhosted.org/packages/03/71/21cf70dc6ea3e3acb95fc53a265b2fc248b981f0194ceb5b475271b8809d/numpy-2.4.6-cp314-cp314-macosx_14_0_x86_64.whl", hash = "sha256:0a041d3d761dc3c35cc56ce0351506a02bcbc25f7b169f652435141a17db9096", size = 6543947, upload-time = "2026-05-18T23:35:47.926Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/91/64288395ee1799bd2e0b04a305dce9666da90c961e1f3fe982a05ee1c036/numpy-2.4.6-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:40fdc1ae7125e518ea98e53e69a4ebc27e1fd50510c47b7ea130cf21e5e1d42b", size = 15685197, upload-time = "2026-05-18T23:35:50.863Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/eb/ebffaa97dc55502df69584a8f0dcf07f69a3e0b3e2323670a2722db9aa39/numpy-2.4.6-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a2c306dea656c12c68f51f4cea133cbe78ca7435eb28c735eac1d3ebe73be6e8", size = 16638245, upload-time = "2026-05-18T23:35:54.752Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/0b/54f9da33128d7e350fab89c7455902eeae70349ee52bddb448dc4a576f45/numpy-2.4.6-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:33111801a01c12a8a1e3721f0a9232f8cfc8ae2c6b7098167e6f623c6073f402", size = 17036587, upload-time = "2026-05-18T23:35:58.355Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/f0/fdebc1052db1cc37c64beb22072d67cd6d1c71adca1299f53dec2b5e20d3/numpy-2.4.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:ae506e6902902557576a26ff33eda8695e7ecb3cb36c3b573a0765dee114ebdb", size = 18363226, upload-time = "2026-05-18T23:36:02.845Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/b4/298628d98c72b57e57f7165ae6a481a1deaf6f3c28262a6e4c739c275930/numpy-2.4.6-cp314-cp314-win32.whl", hash = "sha256:aaf159caa35993cb1f56fb9b8e4610d35758e7ca005412eb1daa856a78c9c4b1", size = 6010196, upload-time = "2026-05-18T23:36:05.92Z" },
+    { url = "https://files.pythonhosted.org/packages/df/ac/46de6dda46478f7942f839e094970be2d4a861e005c4b3bf07c92e291a09/numpy-2.4.6-cp314-cp314-win_amd64.whl", hash = "sha256:b507f5c4c1d508876d1819b6bf9a49d365b96320b5d4993426b33a23ca4b8261", size = 12450334, upload-time = "2026-05-18T23:36:09.107Z" },
+    { url = "https://files.pythonhosted.org/packages/78/92/b8b798ac784102c0da830d2257d59358e3d3d90d1e2b3f2575dad976c5cf/numpy-2.4.6-cp314-cp314-win_arm64.whl", hash = "sha256:6f41ae150c4e32db4f3310cdaf64b1593a03dbabe29eec77fc9b50fe64061df6", size = 10495678, upload-time = "2026-05-18T23:36:12.766Z" },
+    { url = "https://files.pythonhosted.org/packages/30/34/ec28d1aa8115971537c01469ab2011ee96827930f0a124de1000cc2a7ed7/numpy-2.4.6-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ece3d2cfe132e7d51f44a832b303895e6f2d499c5e74dfbdb06ee246147a304a", size = 14823672, upload-time = "2026-05-18T23:36:16.473Z" },
+    { url = "https://files.pythonhosted.org/packages/16/bd/f6d1fede4e54e8042a7ff97bb495510f3c220f94bcd9e8b228e87c92cc0d/numpy-2.4.6-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:e3e5193ef5a3dc73bceee50f7fdc2c90dbb76c42df8d8fae3d1067a583df579e", size = 5328731, upload-time = "2026-05-18T23:36:19.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f0/e105b9e2fd728a9910103884decd6951d9dd73896b914a98d9a231de02ee/numpy-2.4.6-cp314-cp314t-macosx_14_0_x86_64.whl", hash = "sha256:17f9ade344e7d9b464a084d69bcf18fc691cb1db67c62ed80820bf4926d78f0e", size = 6649805, upload-time = "2026-05-18T23:36:22.266Z" },
+    { url = "https://files.pythonhosted.org/packages/82/dd/1206a7ca6ab15e3f02069707ca96222e202af681bb73756da7527f3cb837/numpy-2.4.6-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9cd5ffd25db4e7ba6a375693b3fc0fc1791ec636c17db3720da19bde7180ec43", size = 15730496, upload-time = "2026-05-18T23:36:25.713Z" },
+    { url = "https://files.pythonhosted.org/packages/51/e7/38d3ea825dcab85a591734decb2f6c67caa7c8367d374df1a1c3842f9b07/numpy-2.4.6-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7d92c3819208a60205a12a245c91ad70cb0a85336659b19b834205573ac8456e", size = 16679616, upload-time = "2026-05-18T23:36:29.652Z" },
+    { url = "https://files.pythonhosted.org/packages/93/b7/caabfdf53edf663e0b4eb74d7d405d83baef09eb5e83bcd32d601d72b93e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e85b752a1e912b70eaad4fafbd4d1238007ab221de2009b9a2f5ae7461239895", size = 17085145, upload-time = "2026-05-18T23:36:33.449Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/45/68d7c33a6bcf3e5aa3bdbd57a367e6f615286dfd6482f97e8ffeb734306e/numpy-2.4.6-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:29cb7f67d10b479ff07c17d33e39f78c07f71c40ef30d63c153d340e96cd3fb4", size = 18403813, upload-time = "2026-05-18T23:36:37.369Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/50/0753655aa844c99cd9e018aacf76f130f1bd81d881bb74bc0aef5d73a8ba/numpy-2.4.6-cp314-cp314t-win32.whl", hash = "sha256:260a5d70215b61ab4fadf5c7baacd64821842975eea312125ed3c39a6391b063", size = 6156982, upload-time = "2026-05-18T23:36:40.817Z" },
+    { url = "https://files.pythonhosted.org/packages/b2/d4/7c67becf668f973cb490cec3e98dfd799d866f9c989a54d355672cfa0db6/numpy-2.4.6-cp314-cp314t-win_amd64.whl", hash = "sha256:81a1cca95ed5bb92aa8b10dd2cdc9a0d3853a50fad926c28b5d7e8ea54389627", size = 12638908, upload-time = "2026-05-18T23:36:43.996Z" },
+    { url = "https://files.pythonhosted.org/packages/43/bb/e1c71a4295b1b1d1393d50dbb4f2a36283c6859d9d3892e84f00ec5a91d5/numpy-2.4.6-cp314-cp314t-win_arm64.whl", hash = "sha256:0c9136e14ed34a9e343a31c533d78a9813a69a3148332bce5e9821cb2f996e66", size = 10565867, upload-time = "2026-05-18T23:36:47.114Z" },
+]
+
+[[package]]
 name = "openai"
 version = "2.38.0"
 source = { registry = "https://pypi.org/simple" }
@@ -811,6 +1014,58 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pandas"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "python-dateutil" },
+    { name = "tzdata", marker = "sys_platform == 'emscripten' or sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/87/4341c6252d1c47b08768c3d25ac487362bf403f0313ddae4a2a26c9b1b4c/pandas-3.0.3.tar.gz", hash = "sha256:696a4a00a2a2a35d4e5deb3fc946641b96c944f02230e4f76137fe35d806c4fc", size = 4651414, upload-time = "2026-05-11T18:54:29.21Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/24/f1/392f8c5bfc16f66a0d2d41561c01627c228fe7ed2a0d056ef11315042570/pandas-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fed2ff7fd9779120e388e285fc029bd5cf9490cdd2e4166a9ee22c0e49a9ab09", size = 10357846, upload-time = "2026-05-11T18:52:36.143Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/3d/b16412745651e855f357e5e66930248688378853a6e2698a214e331fba1f/pandas-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:b168fc218fd80a6cbdbdbc1a97ddc7889ed057d7eb45f50d866ceab5f39904c4", size = 9899550, upload-time = "2026-05-11T18:52:38.976Z" },
+    { url = "https://files.pythonhosted.org/packages/31/a8/fa2535168fffcedf67f4f6de28d2dd903a747ca7c8ea6989451aaeb3a92f/pandas-3.0.3-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:0383c72c75cdcca61a9e116e611143902dbfd08bff356829c2f6d1cf40a9ca8c", size = 10412965, upload-time = "2026-05-11T18:52:41.915Z" },
+    { url = "https://files.pythonhosted.org/packages/65/b6/09b01cdbc15224e2850365192d17b7bdebb8bdbd8780ed221fcdf0d9a515/pandas-3.0.3-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6dc0b3fd2169c9157deed50b4d519553a3655c8c6a96027136d654592be973a9", size = 10894600, upload-time = "2026-05-11T18:52:45.02Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/a4/2eb28f2fccb4ced4a2c79ab2a5dee9ade1ebf44922ebad6fea158c9f95d4/pandas-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:7e65d5407dc0b394f509699650e4a2ec01c0514f21850f453fa60f3be79a5dbf", size = 11422824, upload-time = "2026-05-11T18:52:48.058Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/45/830bb57f533a4604b355e07edcb8ea18cf88b5f94e5fca92f27052d7c597/pandas-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f8894dc474d648fe7b6ff0ca9b0bd73950d19952bc1a6534540762c5d79d305c", size = 11950889, upload-time = "2026-05-11T18:52:50.905Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/c5/fc1b368f303087d20e8c9bf3d6ceb186263cfac0ade735cd938538bea839/pandas-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:c7be265b62cef88e253a941e4698604973736dcfe242fdb5198f0f7bc473cdcc", size = 9755463, upload-time = "2026-05-11T18:52:53.386Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bd/fda8f9705b1b09c6ebe14bfc0fa0e4ec8584d54ea673628f157ff55131af/pandas-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:557409bc4178e70ee8d9ddb494798e51ebf6ea59330f6be22c51bab2a7db6c49", size = 9066158, upload-time = "2026-05-11T18:52:56.038Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/90/62d8302883c44308c477e222c3daf7c813a34c8e96985882fbd53d964352/pandas-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:67b3b64c11910cfa29f4e94a14d3bff9ee693b6fc76055e7cad549cee0aec5fa", size = 10331071, upload-time = "2026-05-11T18:52:58.838Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ae/6a6493c783a101f165e4356953ba3c74d6f77f0042fa7d753da9dfbb640c/pandas-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:39436b377d56d2a2e52d0395bdbee171f01068e99af5250509aceeb929f765c7", size = 9875690, upload-time = "2026-05-11T18:53:01.431Z" },
+    { url = "https://files.pythonhosted.org/packages/62/7c/5df8e9f56c69a2769fbe9382a5ef8f2658c007e376434e1e2cbb57ad895f/pandas-3.0.3-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d4be06d68f9ddcfc645b87534911da79a8fbffc7573c80e0edcf42a5020624d8", size = 10381634, upload-time = "2026-05-11T18:53:04.393Z" },
+    { url = "https://files.pythonhosted.org/packages/99/68/1237369725aa617bb358263d535803e3053fdbc593513ec5ed9c9896b5b6/pandas-3.0.3-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a4eeb6830daf35a71cc09649bd823e2b542dac246cdee9614c6e4bd65028cd6a", size = 10891243, upload-time = "2026-05-11T18:53:07.643Z" },
+    { url = "https://files.pythonhosted.org/packages/25/93/77d108e8af7222b4a503ebde0e30215b1c2e4f8e53a526431890f22d5586/pandas-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1928e07221f82db493cd4af1e23c1bfca524a19a4699887975bff68f49a72bfb", size = 11388659, upload-time = "2026-05-11T18:53:10.634Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/bd/eff5b4399f332ac386c853f6cd2bd3fa2ca0061b9f36ecd9c4d7c4265649/pandas-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:51b1fe551acb77dac643c6fda86084d8d446c10fe64b06a9cc29c4cc8540e7f2", size = 11942880, upload-time = "2026-05-11T18:53:13.536Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/20/559ace4200982c3887d0b86bfd0d856a2143ef8ddab63cc07934951a964c/pandas-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:a82d532a3351d435432cd913edbccaf8b8e01d4dd0e5ced5a8d2e8ecd94c7e44", size = 9757091, upload-time = "2026-05-11T18:53:16.306Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/66/69055a09fe200f29f922a3eeec4804611900b95f52d932ece3393c3c0c19/pandas-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:275c14e0fce14a2ec20eee474aecd305478ea3c1e6f6a9d8fe219a165542717e", size = 9057282, upload-time = "2026-05-11T18:53:18.768Z" },
+    { url = "https://files.pythonhosted.org/packages/57/0e/efe801b0e6811e8e650cd21b7f2608e30f08a7067e2bf6e8752b0d56ee3c/pandas-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:46997386d528eb40376ecd6b033cf4a8a1e5282580f68f43de875b78cba2199d", size = 10767016, upload-time = "2026-05-11T18:53:21.227Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/dc/eb55135a1d5f0f0519f28da1f609a206d2cad1f9c35c32d51e38dd7261ae/pandas-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:261e308dfb22448384b7580cf719d2f998fe2966c92893c3e77d14008af1f066", size = 10420210, upload-time = "2026-05-11T18:53:23.982Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/3e/b1d5d955ce33ffecb407465a60bc32769d74fcf68224b7ae67ae11d4dea4/pandas-3.0.3-cp313-cp313t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dd1a5d1def6a46002e964510bdc67c368aa0951df5d1d9f8365336f5a1f490cd", size = 10336126, upload-time = "2026-05-11T18:53:26.731Z" },
+    { url = "https://files.pythonhosted.org/packages/f5/76/a01261711ab60a22d71b862f0de20e4c504bf80457270ad8cb42110f6abc/pandas-3.0.3-cp313-cp313t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d72828c20c6d6e83e1e22a6a3b47b326b71664112fa9705dcbccfd7a39b62085", size = 10728051, upload-time = "2026-05-11T18:53:29.125Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/21/ea191195e587b18cf682e97f433f81b2d0fbe341380e80a3e0d6e4403c8e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:d26cbe1fcfc12e8fd900e2454163e466b2d3af84f7c75481df7683ffc073d870", size = 11350796, upload-time = "2026-05-11T18:53:32.056Z" },
+    { url = "https://files.pythonhosted.org/packages/64/69/f0eaaf54939f0e8c6768fd06be9af2cef9b36048b96dfb9e1b2c685a807e/pandas-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:3e91cec1879ada0624fc3dc9953c5cbd60208e59c0db28f540c5d6d47502422f", size = 11799741, upload-time = "2026-05-11T18:53:34.985Z" },
+    { url = "https://files.pythonhosted.org/packages/45/a4/865e0e510cae5fc2194de4db28be638952de942571ba9125934fd9c01d47/pandas-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:08d789b41f87e0905880e293cedf6197ce71fe67cc081358b1e148a491b9bd13", size = 10499958, upload-time = "2026-05-11T18:53:37.857Z" },
+    { url = "https://files.pythonhosted.org/packages/86/54/effdcc3c0ff7a08037889200e148ebe94c16c4f653be078c7b3675955df1/pandas-3.0.3-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:3650109c0f22879df8bd6179ab9ee3d7f1d1d4e7e0094a3f0032d9f51e2e64ac", size = 10336065, upload-time = "2026-05-11T18:53:41.099Z" },
+    { url = "https://files.pythonhosted.org/packages/68/10/bf2d6738d72748b961a3751ab89522d58c54efc36a8e1a12161216cd45cf/pandas-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:bab900348131a7db1f69a7309ef141fd5680f1487094193bcbbb61791573bf8f", size = 9926101, upload-time = "2026-05-11T18:53:43.515Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/e9/e35cf11c8a136e757b956f5f0efdcaa50aecde85ea055f1898dfc68262f3/pandas-3.0.3-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ba7e08b9ac1d54569cd1e256e3668975ed624d6826f7b68df0342b012007bddb", size = 10457553, upload-time = "2026-05-11T18:53:46.394Z" },
+    { url = "https://files.pythonhosted.org/packages/58/3b/1cdec6772bdbaf7b25dab360c59f03cadf05492dd724c6540af905389b07/pandas-3.0.3-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:9d71c63ae4ebdbf70209742096f1fc46a83a0613c99d4b23766cced9ff8cd62a", size = 10914065, upload-time = "2026-05-11T18:53:49.134Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/c2/1ef644445fcd72e3627bceec77e3560636f87ddce4ed841afe76b83b5bf9/pandas-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:e3a2ec42c98ffa2565a67e08e218d06d72576d758d90facb7c00805194d8f360", size = 11459188, upload-time = "2026-05-11T18:53:52.527Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/49/4d8d4f42cbc9c4adc7a1870f269c02cbd6cd40d059622c06fb298addcbad/pandas-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:335f62418ed562cfc3c49e9e196375c28b729dcef8543abf4f9438e381bf3c76", size = 11982966, upload-time = "2026-05-11T18:53:55.043Z" },
+    { url = "https://files.pythonhosted.org/packages/38/55/792619469bab9882d8bbd5865d45a72f6478762d04a9af4bf0d08c503e95/pandas-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:3c20a521bbb85902f79f7270c80a59e1b5452d96d170c034f207181870f97ac5", size = 9876755, upload-time = "2026-05-11T18:53:58.067Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/af/33c469653b0ba03b50c3a98192d4c07f0c75c66b263ceb097fce0ee97d31/pandas-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:a2d2dff8a04f3917b55ab3910c32990f8ddf7eceba114947838cefa976a68977", size = 9198658, upload-time = "2026-05-11T18:54:00.733Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/fa/b8c257bd76b8bd060c3a9151c1fca05e9b9c5e3af5d0f549c0356f6d143d/pandas-3.0.3-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:0d589105b3c14645af1738ff279b2995102d8f7a03b0a66dc8d95550eb513e04", size = 10787242, upload-time = "2026-05-11T18:54:03.564Z" },
+    { url = "https://files.pythonhosted.org/packages/54/eb/f19206ffb0bf1919002969aa448b4702c6594845156a6f8050674855aac3/pandas-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:13fc1e853d9e04743d11ba75a985ccbc2a317fe07d8af61e445a6fd24dacd6a6", size = 10436369, upload-time = "2026-05-11T18:54:06.311Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/24/c7c39fb4fe22b71a0c2d78bf0c585c600092d85f94f086d2b3b2f6ca27e2/pandas-3.0.3-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:819959dab7bbd0049c15623fbac4e29a191b9528160a61fb1032242d8ced2d9c", size = 10358306, upload-time = "2026-05-11T18:54:09.085Z" },
+    { url = "https://files.pythonhosted.org/packages/16/ec/dd2a9eb7fa1204df88c0864164e35b228ac581062ac612ba0a67fd812e4c/pandas-3.0.3-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:60ae316d3fd75d1858d450d0db0103ea2be3e7d4a95ec2f064f7e2ae63f7b028", size = 10758394, upload-time = "2026-05-11T18:54:11.956Z" },
+    { url = "https://files.pythonhosted.org/packages/95/6e/00c61ea8e85b4f6d8d35e11852a1a4998fc7fafc91c6a602d1cc9c972d64/pandas-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bd3a518890b400d32f9023722dc9a9a5c969f00b415419a3c06c043f09bb5d7d", size = 11375717, upload-time = "2026-05-11T18:54:14.539Z" },
+    { url = "https://files.pythonhosted.org/packages/31/89/8fc1c268969fac43688d65fd92e67df24bd128d53cb4d2eee534cd307399/pandas-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:9c39be2d709d01fa972a0cabc522389fceca4f3969332ba25a7d6c5802cf976a", size = 11828897, upload-time = "2026-05-11T18:54:17.146Z" },
+    { url = "https://files.pythonhosted.org/packages/56/3b/e7d20dea247a3e6dc0bd8a6953854afbedc03951def4e7371e05e7263e25/pandas-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4db8c527972a821cf5286b40ccc57642a39bc62e62022b42f99f8a67fca8c3a1", size = 10900855, upload-time = "2026-05-11T18:54:19.72Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/54/68a0978d1ef8502b8492099beaa6e7a0c1b32e3b5d4f677f5810cb08711c/pandas-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:b2c95f8bfc1ee412bf482605d7bfd30c12d1d26bd59fdd91efeef1d4718decb1", size = 9466464, upload-time = "2026-05-11T18:54:22.754Z" },
 ]
 
 [[package]]
@@ -1099,6 +1354,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pytz"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/46/dd499ec9038423421951e4fad73051febaa13d2df82b4064f87af8b8c0c3/pytz-2026.2.tar.gz", hash = "sha256:0e60b47b29f21574376f218fe21abc009894a2321ea16c6754f3cad6eb7cdd6a", size = 320861, upload-time = "2026-05-04T01:35:29.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ec/dd/96da98f892250475bdf2328112d7468abdd4acc7b902b6af23f4ed958ea0/pytz-2026.2-py2.py3-none-any.whl", hash = "sha256:04156e608bee23d3792fd45c94ae47fae1036688e75032eea2e3bf0323d1f126", size = 510141, upload-time = "2026-05-04T01:35:27.408Z" },
+]
+
+[[package]]
 name = "pywin32"
 version = "311"
 source = { registry = "https://pypi.org/simple" }
@@ -1126,6 +1390,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/22/f5/df4e9027acead3ecc63e50fe1e36aca1523e1719559c499951bb4b53188f/referencing-0.37.0.tar.gz", hash = "sha256:44aefc3142c5b842538163acb373e24cce6632bd54bdb01b21ad5863489f50d8", size = 78036, upload-time = "2025-10-13T15:30:48.871Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/58/ca301544e1fa93ed4f80d724bf5b194f6e4b945841c5bfd555878eea9fcb/referencing-0.37.0-py3-none-any.whl", hash = "sha256:381329a9f99628c9069361716891d34ad94af76e461dcb0335825aecc7692231", size = 26766, upload-time = "2025-10-13T15:30:47.625Z" },
+]
+
+[[package]]
+name = "requests"
+version = "2.34.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "charset-normalizer" },
+    { name = "idna" },
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -1329,6 +1608,14 @@ wheels = [
 ]
 
 [[package]]
+name = "sseclient-py"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4d/2e/59920f7d66b7f9932a3d83dd0ec53fab001be1e058bf582606fe414a5198/sseclient_py-1.9.0-py3-none-any.whl", hash = "sha256:340062b1587fc2880892811e2ab5b176d98ef3eee98b3672ff3a3ba1e8ed0f6f", size = 8351, upload-time = "2026-01-02T23:39:30.995Z" },
+]
+
+[[package]]
 name = "starlette"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1347,6 +1634,7 @@ version = "0.0.1"
 source = { editable = "." }
 dependencies = [
     { name = "alembic" },
+    { name = "alpaca-py" },
     { name = "httpx" },
     { name = "mcp" },
     { name = "openai" },
@@ -1378,6 +1666,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
+    { name = "alpaca-py", specifier = ">=0.30" },
     { name = "httpx", specifier = ">=0.27" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "openai", specifier = ">=1.55" },
@@ -1470,6 +1759,15 @@ wheels = [
 ]
 
 [[package]]
+name = "urllib3"
+version = "2.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/0c/06f8b233b8fd13b9e5ee11424ef85419ba0d8ba0b3138bf360be2ff56953/urllib3-2.7.0.tar.gz", hash = "sha256:231e0ec3b63ceb14667c67be60f2f2c40a518cb38b03af60abc813da26505f4c", size = 433602, upload-time = "2026-05-07T16:13:18.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/3e/5db95bcf282c52709639744ca2a8b149baccf648e39c8cc87553df9eae0c/urllib3-2.7.0-py3-none-any.whl", hash = "sha256:9fb4c81ebbb1ce9531cce37674bbc6f1360472bc18ca9a553ede278ef7276897", size = 131087, upload-time = "2026-05-07T16:13:17.151Z" },
+]
+
+[[package]]
 name = "uvicorn"
 version = "0.48.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1480,4 +1778,49 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+]
+
+[[package]]
+name = "websockets"
+version = "16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/04/24/4b2031d72e840ce4c1ccb255f693b15c334757fc50023e4db9537080b8c4/websockets-16.0.tar.gz", hash = "sha256:5f6261a5e56e8d5c42a4497b364ea24d94d9563e8fbd44e78ac40879c60179b5", size = 179346, upload-time = "2026-01-10T09:23:47.181Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/7b/bac442e6b96c9d25092695578dda82403c77936104b5682307bd4deb1ad4/websockets-16.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:71c989cbf3254fbd5e84d3bff31e4da39c43f884e64f2551d14bb3c186230f00", size = 177365, upload-time = "2026-01-10T09:22:46.787Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/fe/136ccece61bd690d9c1f715baaeefd953bb2360134de73519d5df19d29ca/websockets-16.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:8b6e209ffee39ff1b6d0fa7bfef6de950c60dfb91b8fcead17da4ee539121a79", size = 175038, upload-time = "2026-01-10T09:22:47.999Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1e/9771421ac2286eaab95b8575b0cb701ae3663abf8b5e1f64f1fd90d0a673/websockets-16.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:86890e837d61574c92a97496d590968b23c2ef0aeb8a9bc9421d174cd378ae39", size = 175328, upload-time = "2026-01-10T09:22:49.809Z" },
+    { url = "https://files.pythonhosted.org/packages/18/29/71729b4671f21e1eaa5d6573031ab810ad2936c8175f03f97f3ff164c802/websockets-16.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:9b5aca38b67492ef518a8ab76851862488a478602229112c4b0d58d63a7a4d5c", size = 184915, upload-time = "2026-01-10T09:22:51.071Z" },
+    { url = "https://files.pythonhosted.org/packages/97/bb/21c36b7dbbafc85d2d480cd65df02a1dc93bf76d97147605a8e27ff9409d/websockets-16.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e0334872c0a37b606418ac52f6ab9cfd17317ac26365f7f65e203e2d0d0d359f", size = 186152, upload-time = "2026-01-10T09:22:52.224Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/34/9bf8df0c0cf88fa7bfe36678dc7b02970c9a7d5e065a3099292db87b1be2/websockets-16.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:a0b31e0b424cc6b5a04b8838bbaec1688834b2383256688cf47eb97412531da1", size = 185583, upload-time = "2026-01-10T09:22:53.443Z" },
+    { url = "https://files.pythonhosted.org/packages/47/88/4dd516068e1a3d6ab3c7c183288404cd424a9a02d585efbac226cb61ff2d/websockets-16.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:485c49116d0af10ac698623c513c1cc01c9446c058a4e61e3bf6c19dff7335a2", size = 184880, upload-time = "2026-01-10T09:22:55.033Z" },
+    { url = "https://files.pythonhosted.org/packages/91/d6/7d4553ad4bf1c0421e1ebd4b18de5d9098383b5caa1d937b63df8d04b565/websockets-16.0-cp312-cp312-win32.whl", hash = "sha256:eaded469f5e5b7294e2bdca0ab06becb6756ea86894a47806456089298813c89", size = 178261, upload-time = "2026-01-10T09:22:56.251Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/f0/f3a17365441ed1c27f850a80b2bc680a0fa9505d733fe152fdf5e98c1c0b/websockets-16.0-cp312-cp312-win_amd64.whl", hash = "sha256:5569417dc80977fc8c2d43a86f78e0a5a22fee17565d78621b6bb264a115d4ea", size = 178693, upload-time = "2026-01-10T09:22:57.478Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/9c/baa8456050d1c1b08dd0ec7346026668cbc6f145ab4e314d707bb845bf0d/websockets-16.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:878b336ac47938b474c8f982ac2f7266a540adc3fa4ad74ae96fea9823a02cc9", size = 177364, upload-time = "2026-01-10T09:22:59.333Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/0c/8811fc53e9bcff68fe7de2bcbe75116a8d959ac699a3200f4847a8925210/websockets-16.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:52a0fec0e6c8d9a784c2c78276a48a2bdf099e4ccc2a4cad53b27718dbfd0230", size = 175039, upload-time = "2026-01-10T09:23:01.171Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/82/39a5f910cb99ec0b59e482971238c845af9220d3ab9fa76dd9162cda9d62/websockets-16.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:e6578ed5b6981005df1860a56e3617f14a6c307e6a71b4fff8c48fdc50f3ed2c", size = 175323, upload-time = "2026-01-10T09:23:02.341Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/28/0a25ee5342eb5d5f297d992a77e56892ecb65e7854c7898fb7d35e9b33bd/websockets-16.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:95724e638f0f9c350bb1c2b0a7ad0e83d9cc0c9259f3ea94e40d7b02a2179ae5", size = 184975, upload-time = "2026-01-10T09:23:03.756Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/66/27ea52741752f5107c2e41fda05e8395a682a1e11c4e592a809a90c6a506/websockets-16.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c0204dc62a89dc9d50d682412c10b3542d748260d743500a85c13cd1ee4bde82", size = 186203, upload-time = "2026-01-10T09:23:05.01Z" },
+    { url = "https://files.pythonhosted.org/packages/37/e5/8e32857371406a757816a2b471939d51c463509be73fa538216ea52b792a/websockets-16.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:52ac480f44d32970d66763115edea932f1c5b1312de36df06d6b219f6741eed8", size = 185653, upload-time = "2026-01-10T09:23:06.301Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/67/f926bac29882894669368dc73f4da900fcdf47955d0a0185d60103df5737/websockets-16.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:6e5a82b677f8f6f59e8dfc34ec06ca6b5b48bc4fcda346acd093694cc2c24d8f", size = 184920, upload-time = "2026-01-10T09:23:07.492Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/a1/3d6ccdcd125b0a42a311bcd15a7f705d688f73b2a22d8cf1c0875d35d34a/websockets-16.0-cp313-cp313-win32.whl", hash = "sha256:abf050a199613f64c886ea10f38b47770a65154dc37181bfaff70c160f45315a", size = 178255, upload-time = "2026-01-10T09:23:09.245Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/ae/90366304d7c2ce80f9b826096a9e9048b4bb760e44d3b873bb272cba696b/websockets-16.0-cp313-cp313-win_amd64.whl", hash = "sha256:3425ac5cf448801335d6fdc7ae1eb22072055417a96cc6b31b3861f455fbc156", size = 178689, upload-time = "2026-01-10T09:23:10.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/1d/e88022630271f5bd349ed82417136281931e558d628dd52c4d8621b4a0b2/websockets-16.0-cp314-cp314-macosx_10_15_universal2.whl", hash = "sha256:8cc451a50f2aee53042ac52d2d053d08bf89bcb31ae799cb4487587661c038a0", size = 177406, upload-time = "2026-01-10T09:23:12.178Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/78/e63be1bf0724eeb4616efb1ae1c9044f7c3953b7957799abb5915bffd38e/websockets-16.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:daa3b6ff70a9241cf6c7fc9e949d41232d9d7d26fd3522b1ad2b4d62487e9904", size = 175085, upload-time = "2026-01-10T09:23:13.511Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/f4/d3c9220d818ee955ae390cf319a7c7a467beceb24f05ee7aaaa2414345ba/websockets-16.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fd3cb4adb94a2a6e2b7c0d8d05cb94e6f1c81a0cf9dc2694fb65c7e8d94c42e4", size = 175328, upload-time = "2026-01-10T09:23:14.727Z" },
+    { url = "https://files.pythonhosted.org/packages/63/bc/d3e208028de777087e6fb2b122051a6ff7bbcca0d6df9d9c2bf1dd869ae9/websockets-16.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:781caf5e8eee67f663126490c2f96f40906594cb86b408a703630f95550a8c3e", size = 185044, upload-time = "2026-01-10T09:23:15.939Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6e/9a0927ac24bd33a0a9af834d89e0abc7cfd8e13bed17a86407a66773cc0e/websockets-16.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:caab51a72c51973ca21fa8a18bd8165e1a0183f1ac7066a182ff27107b71e1a4", size = 186279, upload-time = "2026-01-10T09:23:17.148Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/ca/bf1c68440d7a868180e11be653c85959502efd3a709323230314fda6e0b3/websockets-16.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:19c4dc84098e523fd63711e563077d39e90ec6702aff4b5d9e344a60cb3c0cb1", size = 185711, upload-time = "2026-01-10T09:23:18.372Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/f8/fdc34643a989561f217bb477cbc47a3a07212cbda91c0e4389c43c296ebf/websockets-16.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a5e18a238a2b2249c9a9235466b90e96ae4795672598a58772dd806edc7ac6d3", size = 184982, upload-time = "2026-01-10T09:23:19.652Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/d1/574fa27e233764dbac9c52730d63fcf2823b16f0856b3329fc6268d6ae4f/websockets-16.0-cp314-cp314-win32.whl", hash = "sha256:a069d734c4a043182729edd3e9f247c3b2a4035415a9172fd0f1b71658a320a8", size = 177915, upload-time = "2026-01-10T09:23:21.458Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/f1/ae6b937bf3126b5134ce1f482365fde31a357c784ac51852978768b5eff4/websockets-16.0-cp314-cp314-win_amd64.whl", hash = "sha256:c0ee0e63f23914732c6d7e0cce24915c48f3f1512ec1d079ed01fc629dab269d", size = 178381, upload-time = "2026-01-10T09:23:22.715Z" },
+    { url = "https://files.pythonhosted.org/packages/06/9b/f791d1db48403e1f0a27577a6beb37afae94254a8c6f08be4a23e4930bc0/websockets-16.0-cp314-cp314t-macosx_10_15_universal2.whl", hash = "sha256:a35539cacc3febb22b8f4d4a99cc79b104226a756aa7400adc722e83b0d03244", size = 177737, upload-time = "2026-01-10T09:23:24.523Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/40/53ad02341fa33b3ce489023f635367a4ac98b73570102ad2cdd770dacc9a/websockets-16.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:b784ca5de850f4ce93ec85d3269d24d4c82f22b7212023c974c401d4980ebc5e", size = 175268, upload-time = "2026-01-10T09:23:25.781Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/6158d4e459b984f949dcbbb0c5d270154c7618e11c01029b9bbd1bb4c4f9/websockets-16.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:569d01a4e7fba956c5ae4fc988f0d4e187900f5497ce46339c996dbf24f17641", size = 175486, upload-time = "2026-01-10T09:23:27.033Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/2d/7583b30208b639c8090206f95073646c2c9ffd66f44df967981a64f849ad/websockets-16.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:50f23cdd8343b984957e4077839841146f67a3d31ab0d00e6b824e74c5b2f6e8", size = 185331, upload-time = "2026-01-10T09:23:28.259Z" },
+    { url = "https://files.pythonhosted.org/packages/45/b0/cce3784eb519b7b5ad680d14b9673a31ab8dcb7aad8b64d81709d2430aa8/websockets-16.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:152284a83a00c59b759697b7f9e9cddf4e3c7861dd0d964b472b70f78f89e80e", size = 186501, upload-time = "2026-01-10T09:23:29.449Z" },
+    { url = "https://files.pythonhosted.org/packages/19/60/b8ebe4c7e89fb5f6cdf080623c9d92789a53636950f7abacfc33fe2b3135/websockets-16.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:bc59589ab64b0022385f429b94697348a6a234e8ce22544e3681b2e9331b5944", size = 186062, upload-time = "2026-01-10T09:23:31.368Z" },
+    { url = "https://files.pythonhosted.org/packages/88/a8/a080593f89b0138b6cba1b28f8df5673b5506f72879322288b031337c0b8/websockets-16.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:32da954ffa2814258030e5a57bc73a3635463238e797c7375dc8091327434206", size = 185356, upload-time = "2026-01-10T09:23:32.627Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/b6/b9afed2afadddaf5ebb2afa801abf4b0868f42f8539bfe4b071b5266c9fe/websockets-16.0-cp314-cp314t-win32.whl", hash = "sha256:5a4b4cc550cb665dd8a47f868c8d04c8230f857363ad3c9caf7a0c3bf8c61ca6", size = 178085, upload-time = "2026-01-10T09:23:33.816Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/3e/28135a24e384493fa804216b79a6a6759a38cc4ff59118787b9fb693df93/websockets-16.0-cp314-cp314t-win_amd64.whl", hash = "sha256:b14dc141ed6d2dde437cddb216004bcac6a1df0935d79656387bd41632ba0bbd", size = 178531, upload-time = "2026-01-10T09:23:35.016Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/28/258ebab549c2bf3e64d2b0217b973467394a9cea8c42f70418ca2c5d0d2e/websockets-16.0-py3-none-any.whl", hash = "sha256:1637db62fad1dc833276dded54215f2c7fa46912301a24bd94d45d46a011ceec", size = 171598, upload-time = "2026-01-10T09:23:45.395Z" },
 ]


### PR DESCRIPTION
Phase 2 from PROJECT_SPEC.md section 25 — daily windows can produce 50+ candidates per track with reasons; liquidity and data-quality filters apply.

New package src/stockripper/data with:
- Provenance (sha256 content hash) stamped on every external datum
- CandidateReasonCode enum + typed CandidateReason instead of free-form strings
- UniversePolicyParams kept separate from RiskPolicyParams (eligibility vs sizing)
- MarketCapBand classifier and 8 default per-track policies covering everything from conservative to YOLO
- MarketDataAdapter (snapshot, latest_quote, daily_bars, 20-day ADV) over alpaca-py
- NewsAdapter (Alpaca News API) including count_recent_news for the low-visibility filter
- SecEdgarClient with process-wide 10rps sliding-window rate limiter, mandatory contact-email User-Agent, bounded retries on 429/5xx, and TTL caching
- derive_fundamentals: returns None for missing facts (no fabrication) and tags TTM proxies + stale shares-outstanding via data_quality_warnings
- UniverseBuilder: pure logic driven by pluggable assets_loader + SnapshotProvider, sorted deterministically by ADV, with a separate hidden-gem bucket for low-visibility small caps
- AlpacaAssetsLoader and AlpacaSnapshotProvider in src/stockripper/data/live.py wire the builder to real Alpaca data

Integrations factory at src/stockripper/integrations/alpaca exposes paper-only market-data and news clients plus a reference-only paper TradingClient typed as a Protocol exposing only get_all_assets.

Structural guard: tests/test_no_order_surface.py AST-scans src/stockripper/data for any import of order-submitting Alpaca surfaces (MarketOrderRequest, LimitOrderRequest, etc) and fails loudly if any appear. Only the integrations factory and live wiring may import alpaca.trading.client.

New CLI commands:
- stockripper universe policies — print each track's eligibility policy
- stockripper universe build --track <id> — build the live candidate universe for a track
- stockripper research fundamentals <symbol> — pull EDGAR company-facts and derive market cap, revenue, etc
- stockripper research news <symbol> --days <n> — recent headlines from the Alpaca News API

Validation: ruff and mypy --strict clean; 102 of 102 tests pass.