### PR TITLE
Phase 4 (minimal slice): collaborative orchestrator + run-track CLI

### DIFF
--- a/src/stockripper/__main__.py
+++ b/src/stockripper/__main__.py
@@ -12,6 +12,7 @@ import datetime as dt
 import sys
 from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
 import typer
 from alembic import command as alembic_command
@@ -663,6 +664,193 @@ def prompts_show(
     console.print(f"[bold]rendered_content_hash[/bold]: {tmpl.rendered_content_hash}")
     console.print("---")
     console.print(tmpl.render(include_preamble=with_preamble))
+
+
+# ---------------------------------------------------------------------------
+# agents run-track (Phase 4 minimal-slice orchestrator)
+# ---------------------------------------------------------------------------
+@agents_app.command("run-track")
+def agents_run_track(
+    track_id: str = typer.Argument(..., help="Track to run (e.g. balanced, yolo, benchmark)."),
+    symbol: list[str] = typer.Option(  # noqa: B008 - typer pattern
+        ["SPY"], "--symbol", "-s",
+        help="One or more symbols. The orchestrator runs once per symbol.",
+    ),
+    fake: bool = typer.Option(
+        True, "--fake/--no-fake",
+        help="Use the offline CannedCouncilLLM. Pass --no-fake to call real OpenAI.",
+    ),
+    seed: int | None = typer.Option(
+        None, "--seed", help="Optional rng_seed propagated to every agent run."
+    ),
+) -> None:
+    """Run one (track, symbol) collaborative cycle and print the judge's plan.
+
+    Default mode uses the canned offline LLM so council + skeptic + risk +
+    judge all execute end-to-end without network. Pass ``--no-fake`` to use
+    real OpenAI; the judge uses ``OPENAI_MODEL_JUDGE`` and every other agent
+    uses ``OPENAI_MODEL_DEFAULT``.
+    """
+
+    from stockripper.agents.canned_llm import CannedCouncilLLM
+    from stockripper.agents.demo import build_demo_packet
+    from stockripper.agents.llm import LLMClient, OpenAIStructuredClient
+    from stockripper.agents.orchestrator import run_track
+    from stockripper.agents.registry import build_registry
+
+    registry = build_registry()
+    if track_id not in registry.bindings:
+        console.print(f"[red]unknown track: {track_id}[/red]")
+        raise typer.Exit(code=1)
+
+    llm: LLMClient | None = None
+    binding = registry.bindings[track_id]
+    if fake:
+        llm = CannedCouncilLLM()
+        console.print("[yellow]offline mode: using CannedCouncilLLM[/yellow]")
+    elif binding.is_llm_track:
+        settings = load_settings()
+        llm = OpenAIStructuredClient(
+            api_key=settings.openai_api_key.get_secret_value(),
+            default_model=settings.openai_model_default,
+        )
+        for judge in registry.judges.values():
+            judge.model_id_override = settings.openai_model_judge
+        console.print(
+            f"[green]live mode: agents={settings.openai_model_default} "
+            f"judge={settings.openai_model_judge}[/green]"
+        )
+
+    async def _run_all() -> None:
+        for sym in symbol:
+            packet = build_demo_packet(symbol=sym, track_id=track_id)
+            result = await run_track(
+                registry=registry,
+                track_id=track_id,
+                packet=packet,
+                llm=llm,
+                rng_seed=seed,
+            )
+            _print_track_run_result(result)
+
+    asyncio.run(_run_all())
+
+
+def _print_track_run_result(result: Any) -> None:
+    from stockripper.agents.schemas import (
+        AgentRecommendation,
+        AgentRunStatus,
+    )
+
+    console.print()
+    console.print(
+        f"[bold cyan]Track run[/bold cyan] track={result.track_id} "
+        f"symbol={result.packet.symbol} window={result.window_id} "
+        f"run_id={result.run_id}"
+    )
+
+    if result.market_climate is not None:
+        mc = result.market_climate
+        console.print(
+            f"  [blue]market_climate[/blue]: regime={mc.regime.value} "
+            f"breadth={mc.breadth_score} volatility={mc.volatility_score}"
+        )
+
+    council_table = Table(title=f"Council ({len(result.council_runs)} runs)")
+    council_table.add_column("agent_id")
+    council_table.add_column("status")
+    council_table.add_column("action")
+    council_table.add_column("instrument")
+    council_table.add_column("conviction", justify="right")
+    council_table.add_column("notes", overflow="fold")
+    for run in result.council_runs:
+        if (
+            run.status == AgentRunStatus.OK
+            and isinstance(run.output, AgentRecommendation)
+        ):
+            rec = run.output
+            council_table.add_row(
+                run.agent_id,
+                run.status.value,
+                rec.action.value,
+                rec.instrument.value,
+                str(rec.conviction),
+                rec.thesis[:90],
+            )
+        else:
+            council_table.add_row(
+                run.agent_id, run.status.value, "-", "-", "-",
+                (run.quarantine_reason or "")[:90],
+            )
+    console.print(council_table)
+
+    if result.skeptic_run is not None:
+        sk = result.skeptic_run
+        if result.skeptic_report is not None:
+            console.print(
+                f"  [magenta]skeptic[/magenta]: status={sk.status.value} "
+                f"critiques={len(result.skeptic_report.critiques)}"
+            )
+        else:
+            console.print(
+                f"  [red]skeptic quarantined[/red]: {sk.quarantine_reason}"
+            )
+
+    if result.risk_run is not None:
+        rm = result.risk_run
+        if result.risk_report is not None:
+            console.print(
+                f"  [magenta]risk_manager[/magenta]: status={rm.status.value} "
+                f"assessments={len(result.risk_report.assessments)} "
+                f"portfolio_flags={len(result.risk_report.portfolio_level_flags)}"
+            )
+        else:
+            console.print(
+                f"  [red]risk_manager quarantined[/red]: {rm.quarantine_reason}"
+            )
+
+    judge = result.judge_run
+    decision = result.judge_decision
+    if decision is None:
+        console.print(
+            f"  [red]judge quarantined[/red]: {judge.quarantine_reason}"
+        )
+        return
+    plan = decision.plan
+    console.print(
+        f"  [bold green]judge[/bold green] {plan.judge_agent_id} "
+        f"posture={plan.portfolio_posture.value} "
+        f"objective={plan.objective_label} items={len(plan.items)}"
+    )
+    console.print(f"  rationale: {plan.rationale[:180]}")
+    if plan.items:
+        items_table = Table(title=f"Action items ({len(plan.items)})")
+        items_table.add_column("symbol")
+        items_table.add_column("side")
+        items_table.add_column("instrument")
+        items_table.add_column("size", justify="right")
+        items_table.add_column("rationale", overflow="fold")
+        for item in plan.items:
+            size_text = (
+                f"${item.target_notional_usd}"
+                if item.target_notional_usd is not None
+                else f"{item.target_pct_equity}*equity"
+                if item.target_pct_equity is not None
+                else "-"
+            )
+            items_table.add_row(
+                item.symbol,
+                item.side.value,
+                item.instrument.value,
+                size_text,
+                item.rationale[:80],
+            )
+        console.print(items_table)
+
+    if result.quarantined_runs:
+        console.print(
+            f"  [yellow]quarantined runs: {len(result.quarantined_runs)}[/yellow]"
+        )
 
 
 if __name__ == "__main__":  # pragma: no cover - typer dispatch

--- a/src/stockripper/agents/canned_llm.py
+++ b/src/stockripper/agents/canned_llm.py
@@ -1,0 +1,262 @@
+"""Deterministic structured-output LLM that synthesizes valid no-op responses.
+
+Used by the Phase-4 orchestrator's ``--fake`` mode so the full council ->
+adversarial -> judge pipeline can run end-to-end with zero network calls.
+
+Design contract:
+
+* Every synthesized response is a valid pydantic model for the requested
+  schema. Council members emit HOLD (which requires no sizing and no
+  evidence). Skeptic, risk manager, and market climate emit empty/neutral
+  reports. The judge emits a CASH plan with no items.
+* This is deliberately "boring but valid" — a CashPlan with all-HOLD
+  recommendations is the truthful offline outcome. To see real trades
+  without an LLM, run a deterministic baseline track (``benchmark``,
+  ``random_baseline``, ``quant_signal``); to see real LLM-driven trades,
+  pass ``--no-fake`` and supply OpenAI credentials.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any, TypeVar
+
+from pydantic import BaseModel
+
+from stockripper.agents.llm import StructuredResponse, _composite_digest
+from stockripper.agents.schemas import (
+    ActionPlan,
+    AgentRecommendation,
+    EvidencePacket,
+    JudgeDecision,
+    MarketClimateReport,
+    MarketRegime,
+    PortfolioPosture,
+    PromptInjectionReport,
+    RecommendationAction,
+    RecommendationInstrument,
+    RiskManagerReport,
+    SkepticReport,
+)
+
+T = TypeVar("T", bound=BaseModel)
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+class CannedCouncilLLM:
+    """No-network ``LLMClient`` that synthesizes valid neutral outputs.
+
+    The orchestrator calls :meth:`bind_packet` before each per-packet
+    council fanout so symbol / instrument context is available when the
+    synthesizer constructs ``AgentRecommendation`` outputs.
+    """
+
+    def __init__(
+        self,
+        *,
+        model_id: str = "canned-council-v1",
+        fixed_latency_ms: int = 1,
+    ) -> None:
+        self._model_id = model_id
+        self._fixed_latency_ms = fixed_latency_ms
+        self._packet: EvidencePacket | None = None
+        self.calls: list[Mapping[str, Any]] = []
+
+    def bind_packet(self, packet: EvidencePacket) -> None:
+        """Provide per-packet context for the next batch of synthesized calls."""
+
+        self._packet = packet
+
+    def run_structured(
+        self,
+        *,
+        prompt: str,
+        schema: type[T],
+        agent_id: str,
+        model_id: str | None = None,
+        seed: int | None = None,
+        temperature: float = 0.0,
+        top_p: float = 1.0,
+        prompt_content_hash: str,
+        schema_content_hash: str,
+        input_content_hash: str,
+    ) -> StructuredResponse:
+        chosen_model = model_id or self._model_id
+        digest = _composite_digest(
+            model_id=chosen_model,
+            temperature=temperature,
+            top_p=top_p,
+            seed=seed,
+            prompt_content_hash=prompt_content_hash,
+            schema_content_hash=schema_content_hash,
+            input_content_hash=input_content_hash,
+        )
+        synthesized = self._synthesize(schema=schema, agent_id=agent_id)
+        self.calls.append(
+            {
+                "agent_id": agent_id,
+                "schema": schema.__name__,
+                "digest": digest,
+                "prompt_length": len(prompt),
+                "model_id": chosen_model,
+            }
+        )
+        return StructuredResponse(
+            parsed=synthesized,
+            raw_text=synthesized.model_dump_json(),
+            model_id=chosen_model,
+            latency_ms=self._fixed_latency_ms,
+            finish_reason="stop",
+            request_fingerprint_digest=digest,
+        )
+
+    # ------------------------------------------------------------------
+    def _synthesize(self, *, schema: type[T], agent_id: str) -> T:
+        if schema is AgentRecommendation:
+            return self._make_recommendation(agent_id)  # type: ignore[return-value]
+        if schema is MarketClimateReport:
+            return self._make_market_climate(agent_id)  # type: ignore[return-value]
+        if schema is SkepticReport:
+            return self._make_skeptic_report(agent_id)  # type: ignore[return-value]
+        if schema is RiskManagerReport:
+            return self._make_risk_report(agent_id)  # type: ignore[return-value]
+        if schema is JudgeDecision:
+            return self._make_judge_decision(agent_id)  # type: ignore[return-value]
+        if schema is PromptInjectionReport:
+            return self._make_pi_report(agent_id)  # type: ignore[return-value]
+        raise NotImplementedError(
+            f"CannedCouncilLLM has no synthesizer for schema {schema.__name__!r}"
+        )
+
+    # ------------------------------------------------------------------
+    def _make_recommendation(self, agent_id: str) -> AgentRecommendation:
+        packet = self._require_packet(agent_id)
+        return AgentRecommendation(
+            recommendation_id=f"rec_{uuid.uuid4().hex[:16]}",
+            agent_id=agent_id,
+            agent_version="1.0.0",
+            track_id=packet.track_id,
+            symbol=packet.symbol,
+            instrument=_safe_recommendation_instrument(packet.instrument),
+            action=RecommendationAction.HOLD,
+            conviction=Decimal("0.10"),
+            time_horizon_days=30,
+            thesis=(
+                f"[canned] {agent_id}: insufficient evidence in offline mode; "
+                f"holding {packet.symbol}."
+            ),
+            evidence=(),
+            risk_flags=(),
+            prompt_injection_findings=(),
+            multi_leg=None,
+            pair_legs=None,
+            created_at=_now(),
+        )
+
+    def _make_market_climate(self, agent_id: str) -> MarketClimateReport:
+        when = _now()
+        return MarketClimateReport(
+            report_id=f"climate_{uuid.uuid4().hex[:16]}",
+            agent_id=agent_id,
+            agent_version="1.0.0",
+            as_of=when.date(),
+            regime=MarketRegime.UNCERTAIN,
+            breadth_score=Decimal("0"),
+            volatility_score=Decimal("0"),
+            rates_backdrop="unknown",
+            sector_rotation=(),
+            narrative="[canned] No external macro evidence in offline mode.",
+            evidence=(),
+            created_at=when,
+        )
+
+    def _make_skeptic_report(self, agent_id: str) -> SkepticReport:
+        packet = self._require_packet(agent_id)
+        return SkepticReport(
+            report_id=f"skeptic_{uuid.uuid4().hex[:16]}",
+            agent_id=agent_id,
+            agent_version="1.0.0",
+            track_id=packet.track_id,
+            critiques=(),
+            created_at=_now(),
+        )
+
+    def _make_risk_report(self, agent_id: str) -> RiskManagerReport:
+        packet = self._require_packet(agent_id)
+        return RiskManagerReport(
+            report_id=f"risk_{uuid.uuid4().hex[:16]}",
+            agent_id=agent_id,
+            agent_version="1.0.0",
+            track_id=packet.track_id,
+            assessments=(),
+            portfolio_level_flags=(),
+            created_at=_now(),
+        )
+
+    def _make_judge_decision(self, agent_id: str) -> JudgeDecision:
+        packet = self._require_packet(agent_id)
+        plan = ActionPlan(
+            decision_id=f"plan_{uuid.uuid4().hex[:16]}",
+            track_id=packet.track_id,
+            judge_agent_id=agent_id,
+            judge_agent_version="1.0.0",
+            portfolio_posture=PortfolioPosture.CASH,
+            items=(),
+            rationale=(
+                "[canned] Offline judge: council emitted only HOLD signals; "
+                "holding cash for this window."
+            ),
+            objective_label="offline_canned_judge",
+            created_at=_now(),
+        )
+        return JudgeDecision(plan=plan, provenance=None)
+
+    def _make_pi_report(self, agent_id: str) -> PromptInjectionReport:
+        return PromptInjectionReport(
+            report_id=f"pi_{uuid.uuid4().hex[:16]}",
+            agent_id=agent_id,
+            agent_version="1.0.0",
+            findings=(),
+            scanned_evidence_ids=(),
+            created_at=_now(),
+        )
+
+    # ------------------------------------------------------------------
+    def _require_packet(self, agent_id: str) -> EvidencePacket:
+        if self._packet is None:
+            raise RuntimeError(
+                f"CannedCouncilLLM: bind_packet() not called before {agent_id!r}."
+            )
+        return self._packet
+
+
+_PACKET_TO_RECOMMENDATION_INSTRUMENT: dict[
+    RecommendationInstrument, RecommendationInstrument
+] = {
+    # Most packet instruments map 1:1.
+    RecommendationInstrument.EQUITY: RecommendationInstrument.EQUITY,
+    RecommendationInstrument.ETF: RecommendationInstrument.ETF,
+    RecommendationInstrument.LEVERAGED_ETF: RecommendationInstrument.LEVERAGED_ETF,
+    # Option packets degenerate to a safe "underlying-equity HOLD" so HOLD
+    # recommendations don't get caught by multi-leg/pair shape validators.
+    RecommendationInstrument.OPTION_SINGLE: RecommendationInstrument.EQUITY,
+    RecommendationInstrument.MULTI_LEG_OPTION: RecommendationInstrument.EQUITY,
+    RecommendationInstrument.PAIR: RecommendationInstrument.EQUITY,
+}
+
+
+def _safe_recommendation_instrument(
+    packet_instrument: RecommendationInstrument,
+) -> RecommendationInstrument:
+    """Pick an instrument that lets HOLD pass the multi-leg/pair validators."""
+
+    return _PACKET_TO_RECOMMENDATION_INSTRUMENT[packet_instrument]
+
+
+__all__ = ("CannedCouncilLLM",)

--- a/src/stockripper/agents/demo.py
+++ b/src/stockripper/agents/demo.py
@@ -1,0 +1,81 @@
+"""Synthesize a minimal :class:`EvidencePacket` from a symbol + light metadata.
+
+Used by ``stockripper agents run-track`` so the CLI can demo the
+collaborative pipeline without a full Phase-2 universe build. Production
+runs would call :func:`stockripper.agents.evidence.build_evidence_packet`
+directly with real ``Candidate`` instances.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import uuid
+from decimal import Decimal
+
+from stockripper.agents.schemas import (
+    EvidencePacket,
+    RecommendationInstrument,
+)
+from stockripper.data.reasons import CandidateReason, CandidateReasonCode
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def build_demo_packet(
+    *,
+    symbol: str,
+    track_id: str,
+    window_id: str | None = None,
+    last_price: Decimal | None = None,
+    adv_usd_20d: Decimal | None = None,
+    market_cap_usd: Decimal | None = None,
+    recent_8k_within_days: int | None = None,
+    recent_news_count_30d: int | None = None,
+    instrument: RecommendationInstrument = RecommendationInstrument.EQUITY,
+    bucket: str = "core",
+    now: dt.datetime | None = None,
+) -> EvidencePacket:
+    """Build a self-contained packet for offline orchestrator demos."""
+
+    when = now if now is not None else _now()
+    wid = window_id or when.strftime("demo-%Y%m%dT%H%M%SZ")
+    reasons: tuple[CandidateReason, ...] = (
+        CandidateReason(
+            code=CandidateReasonCode.PASSES_PRICE_FLOOR,
+            params={"instrument": "equity_long"},
+        ),
+        CandidateReason(
+            code=CandidateReasonCode.PASSES_ADV_FLOOR,
+            params={"adv_usd_20d": str(adv_usd_20d) if adv_usd_20d is not None else "unknown"},
+        ),
+    )
+    summary_bits = [f"symbol={symbol}", f"bucket={bucket}"]
+    if last_price is not None:
+        summary_bits.append(f"price=${last_price}")
+    if adv_usd_20d is not None:
+        summary_bits.append(f"adv20=${int(adv_usd_20d):,}")
+    if market_cap_usd is not None:
+        summary_bits.append(f"cap=${int(market_cap_usd):,}")
+    if recent_8k_within_days is not None:
+        summary_bits.append(f"last_8k={recent_8k_within_days}d")
+    if recent_news_count_30d is not None:
+        summary_bits.append(f"news30={recent_news_count_30d}")
+    summary = " ".join(summary_bits) or f"symbol={symbol}"
+    return EvidencePacket(
+        packet_id=f"pkt_demo_{uuid.uuid4().hex[:12]}",
+        track_id=track_id,
+        window_id=wid,
+        symbol=symbol.upper(),
+        instrument=instrument,
+        candidate_reasons=reasons,
+        snapshot_summary=summary,
+        evidence_refs=(),
+        provenances=(),
+        prompt_injection_report=None,
+        as_of=when,
+    )
+
+
+__all__ = ("build_demo_packet",)

--- a/src/stockripper/agents/llm.py
+++ b/src/stockripper/agents/llm.py
@@ -104,6 +104,18 @@ def schema_content_hash(schema: type[BaseModel]) -> str:
 _DEFAULT_TEMPERATURE: Final[float] = 0.0
 
 
+def _model_supports_sampling_params(model_id: str) -> bool:
+    """Whether a model accepts ``temperature`` / ``top_p`` on the Responses API.
+
+    The gpt-5 family (gpt-5, gpt-5-mini, gpt-5-nano, gpt-5-turbo, ...) and
+    the o-series reasoning models reject these parameters; everything else
+    is assumed to accept them.
+    """
+
+    lowered = model_id.lower()
+    return not (lowered.startswith(("gpt-5", "o1", "o3", "o4")))
+
+
 class OpenAIStructuredClient:
     """Production implementation. Uses the structured-output API."""
 
@@ -145,16 +157,31 @@ class OpenAIStructuredClient:
             schema_content_hash=schema_content_hash,
             input_content_hash=input_content_hash,
         )
+        extra: dict[str, Any] = {}
+        if _model_supports_sampling_params(chosen_model):
+            extra["temperature"] = temperature
+            extra["top_p"] = top_p
+            if seed is not None:
+                extra["seed"] = seed
         started = time.perf_counter()
-        response: Any = self._client.responses.parse(
-            model=chosen_model,
-            input=prompt,
-            text_format=schema,
-            temperature=temperature,
-            top_p=top_p,
-            **({"seed": seed} if seed is not None else {}),
-            metadata={"agent_id": agent_id, "fingerprint": digest[:32]},
-        )
+        try:
+            response: Any = self._client.responses.parse(
+                model=chosen_model,
+                input=prompt,
+                text_format=schema,
+                metadata={"agent_id": agent_id, "fingerprint": digest[:32]},
+                **extra,
+            )
+        except Exception as exc:
+            # BaseAgent.run() only catches ValueError/KeyError/RuntimeError when
+            # mapping LLM failures to AgentRunStatus.QUARANTINED. The OpenAI
+            # client raises its own exception types (BadRequestError, etc.) for
+            # transport, schema, and rate-limit errors; wrap them so agents
+            # degrade gracefully instead of crashing the orchestrator.
+            raise RuntimeError(
+                f"OpenAI structured call failed for agent_id={agent_id!r} "
+                f"model={chosen_model!r}: {exc}"
+            ) from exc
         latency_ms = int((time.perf_counter() - started) * 1000)
         parsed = response.output_parsed
         if parsed is None:
@@ -165,7 +192,7 @@ class OpenAIStructuredClient:
             parsed.model_dump(mode="json"), default=str
         )
         finish = "stop"
-        with contextlib.suppress(AttributeError, IndexError):
+        with contextlib.suppress(AttributeError, IndexError, TypeError):
             finish = response.output[0].content[0].finish_reason or "stop"
         return StructuredResponse(
             parsed=parsed,

--- a/src/stockripper/agents/orchestrator.py
+++ b/src/stockripper/agents/orchestrator.py
@@ -1,0 +1,338 @@
+"""Phase-4 minimal-slice orchestrator.
+
+Runs one (track, packet) collaborative cycle:
+
+    market_climate (LLM tracks only)
+        -> council fanout (parallel)
+            -> skeptic + risk_manager (LLM tracks only, parallel)
+                -> judge
+
+Every step uses :class:`BaseAgent.run` so failures quarantine cleanly
+instead of crashing the cycle. ``llm`` may be ``None`` for purely
+deterministic baseline tracks; LLM tracks require an :class:`LLMClient`
+(real ``OpenAIStructuredClient`` or the offline :class:`CannedCouncilLLM`).
+
+This is intentionally NOT LangGraph — it is the smallest useful slice
+that exercises every Phase-3 surface end-to-end so we can observe agents
+collaborating. Real graph wiring, checkpoints, persistence of
+``agent_runs`` / ``judge_decisions``, and parallel sub-graphs per track
+all land in the full Phase 4 PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import uuid
+from dataclasses import dataclass
+from typing import Any
+
+from stockripper.agents.adversarial import (
+    empty_risk_manager_report,
+    empty_skeptic_report,
+)
+from stockripper.agents.base import BaseAgent
+from stockripper.agents.canned_llm import CannedCouncilLLM
+from stockripper.agents.council import empty_market_climate
+from stockripper.agents.llm import LLMClient
+from stockripper.agents.registry import AgentRegistry
+from stockripper.agents.schemas import (
+    AgentRecommendation,
+    AgentRunInput,
+    AgentRunResult,
+    AgentRunStatus,
+    EvidencePacket,
+    JudgeDecision,
+    MarketClimateReport,
+    RiskManagerReport,
+    SkepticReport,
+)
+
+
+def _now() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+@dataclass(frozen=True)
+class TrackRunResult:
+    """All :class:`AgentRunResult` envelopes produced by one ``run_track`` call."""
+
+    track_id: str
+    window_id: str
+    run_id: str
+    packet: EvidencePacket
+    market_climate_run: AgentRunResult | None
+    council_runs: tuple[AgentRunResult, ...]
+    skeptic_run: AgentRunResult | None
+    risk_run: AgentRunResult | None
+    judge_run: AgentRunResult
+
+    @property
+    def all_runs(self) -> tuple[AgentRunResult, ...]:
+        parts: list[AgentRunResult] = []
+        if self.market_climate_run is not None:
+            parts.append(self.market_climate_run)
+        parts.extend(self.council_runs)
+        if self.skeptic_run is not None:
+            parts.append(self.skeptic_run)
+        if self.risk_run is not None:
+            parts.append(self.risk_run)
+        parts.append(self.judge_run)
+        return tuple(parts)
+
+    @property
+    def council_recommendations(self) -> tuple[AgentRecommendation, ...]:
+        return tuple(
+            r.output
+            for r in self.council_runs
+            if r.status == AgentRunStatus.OK
+            and isinstance(r.output, AgentRecommendation)
+        )
+
+    @property
+    def market_climate(self) -> MarketClimateReport | None:
+        run = self.market_climate_run
+        if (
+            run is not None
+            and run.status == AgentRunStatus.OK
+            and isinstance(run.output, MarketClimateReport)
+        ):
+            return run.output
+        return None
+
+    @property
+    def skeptic_report(self) -> SkepticReport | None:
+        if (
+            self.skeptic_run is not None
+            and self.skeptic_run.status == AgentRunStatus.OK
+            and isinstance(self.skeptic_run.output, SkepticReport)
+        ):
+            return self.skeptic_run.output
+        return None
+
+    @property
+    def risk_report(self) -> RiskManagerReport | None:
+        if (
+            self.risk_run is not None
+            and self.risk_run.status == AgentRunStatus.OK
+            and isinstance(self.risk_run.output, RiskManagerReport)
+        ):
+            return self.risk_run.output
+        return None
+
+    @property
+    def judge_decision(self) -> JudgeDecision | None:
+        if (
+            self.judge_run.status == AgentRunStatus.OK
+            and isinstance(self.judge_run.output, JudgeDecision)
+        ):
+            return self.judge_run.output
+        return None
+
+    @property
+    def quarantined_runs(self) -> tuple[AgentRunResult, ...]:
+        return tuple(
+            r for r in self.all_runs if r.status == AgentRunStatus.QUARANTINED
+        )
+
+
+def _build_input(
+    *,
+    track_id: str,
+    window_id: str,
+    agent_id: str,
+    packet: EvidencePacket,
+    council_outputs: tuple[AgentRecommendation, ...] = (),
+    market_climate: MarketClimateReport | None = None,
+    skeptic_report: SkepticReport | None = None,
+    risk_manager_report: RiskManagerReport | None = None,
+    rng_seed: int | None = None,
+    now: dt.datetime,
+) -> AgentRunInput:
+    return AgentRunInput(
+        run_id=f"run_{uuid.uuid4().hex[:16]}",
+        track_id=track_id,
+        window_id=window_id,
+        agent_id=agent_id,
+        packet=packet,
+        council_outputs=council_outputs,
+        market_climate=market_climate,
+        skeptic_report=skeptic_report,
+        risk_manager_report=risk_manager_report,
+        rng_seed=rng_seed,
+        created_at=now,
+    )
+
+
+async def _run_one(
+    agent: BaseAgent[Any],
+    payload: AgentRunInput,
+    *,
+    llm: LLMClient | None,
+    seed: int | None,
+) -> AgentRunResult:
+    return await asyncio.to_thread(agent.run, payload, llm=llm, seed=seed)
+
+
+async def run_track(
+    *,
+    registry: AgentRegistry,
+    track_id: str,
+    packet: EvidencePacket,
+    llm: LLMClient | None = None,
+    rng_seed: int | None = None,
+    window_id: str | None = None,
+    now: dt.datetime | None = None,
+) -> TrackRunResult:
+    """Run one (track, packet) collaborative cycle and return all envelopes."""
+
+    when = now if now is not None else _now()
+    wid = window_id or packet.window_id
+    if track_id not in registry.bindings:
+        raise KeyError(f"unknown track_id: {track_id!r}")
+    binding = registry.bindings[track_id]
+    run_id = f"trackrun_{uuid.uuid4().hex[:16]}"
+
+    if isinstance(llm, CannedCouncilLLM):
+        llm.bind_packet(packet)
+
+    # ------------------------------------------------------------------
+    # Step 1: market climate (LLM tracks only).
+    # ------------------------------------------------------------------
+    climate_run: AgentRunResult | None = None
+    climate_for_council: MarketClimateReport | None = None
+    if binding.market_climate_enabled:
+        mc_input = _build_input(
+            track_id=track_id,
+            window_id=wid,
+            agent_id=registry.market_climate.agent_id,
+            packet=packet,
+            rng_seed=rng_seed,
+            now=when,
+        )
+        climate_run = await _run_one(
+            registry.market_climate, mc_input, llm=llm, seed=rng_seed
+        )
+        if (
+            climate_run.status == AgentRunStatus.OK
+            and isinstance(climate_run.output, MarketClimateReport)
+        ):
+            climate_for_council = climate_run.output
+        else:
+            climate_for_council = empty_market_climate(as_of=when)
+
+    # ------------------------------------------------------------------
+    # Step 2: council fanout in parallel.
+    # ------------------------------------------------------------------
+    council_agents = registry.council_for(track_id)
+    council_inputs = [
+        _build_input(
+            track_id=track_id,
+            window_id=wid,
+            agent_id=agent.agent_id,
+            packet=packet,
+            market_climate=climate_for_council,
+            rng_seed=rng_seed,
+            now=when,
+        )
+        for agent in council_agents
+    ]
+    council_runs = tuple(
+        await asyncio.gather(
+            *(
+                _run_one(agent, payload, llm=llm, seed=rng_seed)
+                for agent, payload in zip(
+                    council_agents, council_inputs, strict=True
+                )
+            )
+        )
+    )
+    recommendations = tuple(
+        r.output
+        for r in council_runs
+        if r.status == AgentRunStatus.OK
+        and isinstance(r.output, AgentRecommendation)
+    )
+
+    # ------------------------------------------------------------------
+    # Step 3: adversarial pass (LLM tracks only).
+    # ------------------------------------------------------------------
+    skeptic_run: AgentRunResult | None = None
+    risk_run: AgentRunResult | None = None
+    skeptic_for_judge: SkepticReport | None = None
+    risk_for_judge: RiskManagerReport | None = None
+    if binding.is_llm_track and binding.adversarial_agent_ids:
+        skeptic_input = _build_input(
+            track_id=track_id,
+            window_id=wid,
+            agent_id=registry.skeptic.agent_id,
+            packet=packet,
+            council_outputs=recommendations,
+            market_climate=climate_for_council,
+            rng_seed=rng_seed,
+            now=when,
+        )
+        risk_input = _build_input(
+            track_id=track_id,
+            window_id=wid,
+            agent_id=registry.risk_manager.agent_id,
+            packet=packet,
+            council_outputs=recommendations,
+            market_climate=climate_for_council,
+            rng_seed=rng_seed,
+            now=when,
+        )
+        skeptic_result, risk_result = await asyncio.gather(
+            _run_one(registry.skeptic, skeptic_input, llm=llm, seed=rng_seed),
+            _run_one(registry.risk_manager, risk_input, llm=llm, seed=rng_seed),
+        )
+        skeptic_run = skeptic_result
+        risk_run = risk_result
+        if (
+            skeptic_result.status == AgentRunStatus.OK
+            and isinstance(skeptic_result.output, SkepticReport)
+        ):
+            skeptic_for_judge = skeptic_result.output
+        else:
+            skeptic_for_judge = empty_skeptic_report(track_id=track_id, now=when)
+        if (
+            risk_result.status == AgentRunStatus.OK
+            and isinstance(risk_result.output, RiskManagerReport)
+        ):
+            risk_for_judge = risk_result.output
+        else:
+            risk_for_judge = empty_risk_manager_report(track_id=track_id, now=when)
+
+    # ------------------------------------------------------------------
+    # Step 4: judge.
+    # ------------------------------------------------------------------
+    judge_agent = registry.judge_for(track_id)
+    judge_input = _build_input(
+        track_id=track_id,
+        window_id=wid,
+        agent_id=judge_agent.agent_id,
+        packet=packet,
+        council_outputs=recommendations,
+        market_climate=climate_for_council,
+        skeptic_report=skeptic_for_judge,
+        risk_manager_report=risk_for_judge,
+        rng_seed=rng_seed,
+        now=when,
+    )
+    judge_llm = llm if judge_agent.requires_llm else None
+    judge_run = await _run_one(judge_agent, judge_input, llm=judge_llm, seed=rng_seed)
+
+    return TrackRunResult(
+        track_id=track_id,
+        window_id=wid,
+        run_id=run_id,
+        packet=packet,
+        market_climate_run=climate_run,
+        council_runs=council_runs,
+        skeptic_run=skeptic_run,
+        risk_run=risk_run,
+        judge_run=judge_run,
+    )
+
+
+__all__ = ("TrackRunResult", "run_track")

--- a/tests/test_agent_orchestrator.py
+++ b/tests/test_agent_orchestrator.py
@@ -1,0 +1,222 @@
+"""Tests for the Phase-4 minimal-slice orchestrator."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+from collections.abc import Coroutine
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from stockripper.agents.canned_llm import CannedCouncilLLM
+from stockripper.agents.demo import build_demo_packet
+from stockripper.agents.llm import FakeLLMClient
+from stockripper.agents.orchestrator import TrackRunResult, run_track
+from stockripper.agents.registry import AgentRegistry, build_registry
+from stockripper.agents.schemas import (
+    AgentRecommendation,
+    AgentRunStatus,
+    EvidencePacket,
+    JudgeDecision,
+    RecommendationAction,
+    RecommendationInstrument,
+)
+
+
+@pytest.fixture(scope="module")
+def registry() -> AgentRegistry:
+    return build_registry()
+
+
+@pytest.fixture
+def packet() -> EvidencePacket:
+    return build_demo_packet(
+        symbol="AAPL",
+        track_id="balanced",
+        last_price=Decimal("220"),
+        adv_usd_20d=Decimal("50000000000"),
+        market_cap_usd=Decimal("3500000000000"),
+        recent_8k_within_days=12,
+        recent_news_count_30d=8,
+    )
+
+
+def _run[T](coro: Coroutine[Any, Any, T]) -> T:
+    return asyncio.run(coro)
+
+
+def test_canned_llm_track_returns_judge_decision(
+    registry: AgentRegistry, packet: EvidencePacket
+) -> None:
+    llm = CannedCouncilLLM()
+    result = _run(
+        run_track(
+            registry=registry,
+            track_id="balanced",
+            packet=packet,
+            llm=llm,
+            rng_seed=7,
+        )
+    )
+    assert isinstance(result, TrackRunResult)
+    assert result.track_id == "balanced"
+    assert result.market_climate_run is not None
+    assert result.market_climate is not None
+    assert result.skeptic_report is not None
+    assert result.risk_report is not None
+
+    binding = registry.bindings["balanced"]
+    assert len(result.council_runs) == len(binding.council_agent_ids)
+
+    ok_runs = [r for r in result.council_runs if r.status == AgentRunStatus.OK]
+    assert len(ok_runs) == len(result.council_runs)
+    for run in ok_runs:
+        assert isinstance(run.output, AgentRecommendation)
+        assert run.output.action == RecommendationAction.HOLD
+
+    decision = result.judge_decision
+    assert isinstance(decision, JudgeDecision)
+    assert decision.plan.judge_agent_id == "judge_balanced"
+
+
+def test_canned_llm_track_calls_every_agent(
+    registry: AgentRegistry, packet: EvidencePacket
+) -> None:
+    llm = CannedCouncilLLM()
+    _run(
+        run_track(
+            registry=registry,
+            track_id="aggressive",
+            packet=packet.model_copy(update={"track_id": "aggressive"}),
+            llm=llm,
+        )
+    )
+    binding = registry.bindings["aggressive"]
+    # adversarial_agent_ids lists 3 (skeptic, risk_manager, prompt_injection_detector)
+    # but the PI detector runs at evidence-packet build time, not during the
+    # orchestrator run. So 2 adversarial LLM calls fire here.
+    expected = (
+        1  # market_climate
+        + len(binding.council_agent_ids)
+        + 2  # skeptic + risk_manager
+        + 1  # judge
+    )
+    assert len(llm.calls) == expected
+
+
+def test_baseline_track_benchmark_emits_buy_spy(
+    registry: AgentRegistry,
+) -> None:
+    packet = build_demo_packet(symbol="SPY", track_id="benchmark")
+    llm = CannedCouncilLLM()
+    result = _run(
+        run_track(
+            registry=registry,
+            track_id="benchmark",
+            packet=packet,
+            llm=llm,
+        )
+    )
+    assert result.market_climate_run is None
+    assert result.skeptic_run is None
+    assert result.risk_run is None
+    decision = result.judge_decision
+    assert decision is not None
+    assert len(decision.plan.items) == 1
+    item = decision.plan.items[0]
+    assert item.symbol == "SPY"
+    assert item.instrument == RecommendationInstrument.ETF
+
+
+def test_unknown_track_raises_key_error(
+    registry: AgentRegistry, packet: EvidencePacket
+) -> None:
+    with pytest.raises(KeyError):
+        _run(
+            run_track(
+                registry=registry,
+                track_id="does-not-exist",
+                packet=packet,
+                llm=CannedCouncilLLM(),
+            )
+        )
+
+
+def test_council_quarantines_when_llm_returns_garbage(
+    registry: AgentRegistry, packet: EvidencePacket
+) -> None:
+    # FakeLLMClient with no canned responses -> KeyError -> quarantine.
+    broken_llm = FakeLLMClient(canned={})
+    result = _run(
+        run_track(
+            registry=registry,
+            track_id="balanced",
+            packet=packet,
+            llm=broken_llm,
+        )
+    )
+    assert all(r.status == AgentRunStatus.QUARANTINED for r in result.council_runs)
+    # Judge ran with empty council recommendations; status still defined.
+    assert result.judge_run is not None
+    # Skeptic and risk still ran (and also quarantined under FakeLLMClient).
+    assert result.skeptic_run is not None
+    assert result.risk_run is not None
+    assert result.skeptic_run.status == AgentRunStatus.QUARANTINED
+    assert result.risk_run.status == AgentRunStatus.QUARANTINED
+    # judge_decision can be None when judge quarantined under garbage LLM.
+    if result.judge_decision is not None:
+        assert isinstance(result.judge_decision, JudgeDecision)
+
+
+def test_run_track_propagates_rng_seed(
+    registry: AgentRegistry, packet: EvidencePacket
+) -> None:
+    llm = CannedCouncilLLM()
+    result = _run(
+        run_track(
+            registry=registry,
+            track_id="balanced",
+            packet=packet,
+            llm=llm,
+            rng_seed=123,
+        )
+    )
+    for r in result.all_runs:
+        if r.status == AgentRunStatus.OK:
+            assert r.fingerprint.seed == 123
+
+
+def test_run_track_window_id_override(
+    registry: AgentRegistry, packet: EvidencePacket
+) -> None:
+    llm = CannedCouncilLLM()
+    result = _run(
+        run_track(
+            registry=registry,
+            track_id="balanced",
+            packet=packet,
+            llm=llm,
+            window_id="explicit-window-2026Q2",
+        )
+    )
+    assert result.window_id == "explicit-window-2026Q2"
+
+
+def test_run_track_uses_canned_clock_when_supplied(
+    registry: AgentRegistry, packet: EvidencePacket
+) -> None:
+    now = dt.datetime(2026, 5, 27, 19, 0, 0, tzinfo=dt.UTC)
+    llm = CannedCouncilLLM()
+    result = _run(
+        run_track(
+            registry=registry,
+            track_id="balanced",
+            packet=packet,
+            llm=llm,
+            now=now,
+        )
+    )
+    assert result.market_climate is not None
+    assert result.market_climate.as_of == now.date()


### PR DESCRIPTION
Adds the smallest end-to-end orchestrator on top of the Phase-3 agent graph so a chosen track can finally execute climate then council fanout then skeptic + risk then judge in a single run. Answers the user question can the agents do something collaboratively yet with yes.

New surfaces:

* src/stockripper/agents/orchestrator.py async run_track runs the full sequence with asyncio.gather for council and adversarial fanout. TrackRunResult dataclass exposes typed accessors for council recommendations, adversarial reports, judge decision, and quarantined runs.
* src/stockripper/agents/canned_llm.py CannedCouncilLLM synthesizes schema-valid no-op outputs per output type (HOLD recommendations, UNCERTAIN climate, empty skeptic and risk reports, CASH judge plan) so offline demos and tests are deterministic with zero network calls.
* src/stockripper/agents/demo.py build_demo_packet constructs a one-symbol EvidencePacket without a Phase-2 universe build.
* stockripper agents run-track TRACK_ID --symbol AAPL [--fake|--no-fake] CLI command renders the full collaborative run with Rich tables.

Live OpenAI wiring:

* llm.py omits temperature, top_p, and seed for gpt-5, o1, o3, and o4 model families (these reject sampling params on the Responses API) while preserving them in the request fingerprint for traceability.
* OpenAI client errors are normalized to RuntimeError so BaseAgent quarantines them gracefully instead of crashing the orchestrator.
* finish_reason extraction is defensive against None output payloads.

Validation:

* 8 new tests in tests/test_agent_orchestrator.py covering canned LLM happy path, call counts, baseline benchmark, unknown track, garbage-LLM quarantine, rng_seed propagation, window_id override, and custom clock.
* uv run ruff check . clean.
* uv run mypy src/stockripper tests strict clean across 69 files.
* uv run pytest -q passes 182/182.
* CLI smoke: agents run-track benchmark --symbol SPY emits a real buy-and-hold ActionPlan; balanced --fake emits a full CASH judge plan; balanced --no-fake reaches OpenAI end-to-end and quarantines gracefully on the remaining strict-mode schema gaps.

Known follow-ups (out of scope for this slice):

* OpenAI structured-output strict mode requires additionalProperties false and all-fields-required on every nested object; several agent output schemas (RiskFlag.params dict[str, Any] and friends) need a dedicated strictify pass before the live OpenAI path can return non-quarantined outputs.
* No persistence yet; the full LangGraph state machine and agent_runs / judge_decisions tables remain deferred to full Phase 4.