### PR TITLE
feat(phase4): Strategy Tracks Manager + replay-deterministic IDs

### DIFF
--- a/src/stockripper/__main__.py
+++ b/src/stockripper/__main__.py
@@ -42,12 +42,16 @@ universe_app = typer.Typer(help="Candidate universe construction and inspection.
 research_app = typer.Typer(help="Per-symbol research probes (fundamentals, news).")
 agents_app = typer.Typer(help="Inspect the Phase-3 agent graph (council, judges, baselines).")
 prompts_app = typer.Typer(help="Inspect the content-addressed prompt registry.")
+kill_app = typer.Typer(help="Global kill-switch (halt every track immediately).")
+track_app = typer.Typer(help="Per-track pause control.")
 app.add_typer(db_app, name="db")
 app.add_typer(tracks_app, name="tracks")
 app.add_typer(universe_app, name="universe")
 app.add_typer(research_app, name="research")
 app.add_typer(agents_app, name="agents")
 app.add_typer(prompts_app, name="prompts")
+app.add_typer(kill_app, name="kill")
+app.add_typer(track_app, name="track")
 console = Console()
 
 
@@ -855,4 +859,274 @@ def _print_track_run_result(result: Any) -> None:
 
 if __name__ == "__main__":  # pragma: no cover - typer dispatch
     app()
+
+
+# ---------------------------------------------------------------------------
+# Kill switch (global halt)
+# ---------------------------------------------------------------------------
+def _kill_switch_factory(database_url: str | None) -> Any:
+    from sqlalchemy.orm import sessionmaker
+
+    engine = build_engine(database_url)
+    return sessionmaker(engine, expire_on_commit=False, autoflush=False)
+
+
+@kill_app.command("on")
+def kill_on(
+    reason: str = typer.Argument(..., help="Why are we halting?"),
+    by: str | None = typer.Option(None, "--by", help="Operator id or username."),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Engage the global kill-switch. Every track aborts on its next window."""
+
+    from stockripper.db.repository import Repository
+
+    factory = _kill_switch_factory(database_url)
+    with session_scope(factory) as session:
+        repo = Repository(session)
+        state = repo.engage_kill_switch(reason=reason, engaged_by=by)
+        console.print(
+            f"[bold red]KILL SWITCH ENGAGED[/] reason={state.reason!r} by={state.engaged_by!r} "
+            f"at={state.engaged_at!s}"
+        )
+
+
+@kill_app.command("off")
+def kill_off(
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Release the global kill-switch."""
+
+    from stockripper.db.repository import Repository
+
+    factory = _kill_switch_factory(database_url)
+    with session_scope(factory) as session:
+        repo = Repository(session)
+        state = repo.release_kill_switch()
+        console.print(
+            f"[bold green]kill switch released[/] updated_at={state.updated_at!s}"
+        )
+
+
+@kill_app.command("status")
+def kill_status(
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Print kill-switch status."""
+
+    from stockripper.db.repository import Repository
+
+    factory = _kill_switch_factory(database_url)
+    with session_scope(factory) as session:
+        repo = Repository(session)
+        state = repo.get_kill_switch()
+        if state.engaged:
+            console.print(
+                f"[bold red]ENGAGED[/] reason={state.reason!r} by={state.engaged_by!r} "
+                f"at={state.engaged_at!s}"
+            )
+        else:
+            console.print(
+                f"[bold green]not engaged[/] last_updated={state.updated_at!s}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Per-track pause control
+# ---------------------------------------------------------------------------
+@track_app.command("pause")
+def track_pause(
+    track_id: str = typer.Argument(..., help="track_id to pause."),
+    reason: str = typer.Option("manual", "--reason", help="Why is this track paused?"),
+    by: str | None = typer.Option(None, "--by", help="Operator id or username."),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Pause one track; future windows skip it until resumed."""
+
+    from stockripper.db.repository import Repository
+
+    factory = _kill_switch_factory(database_url)
+    with session_scope(factory) as session:
+        repo = Repository(session)
+        state = repo.pause_track(track_id=track_id, reason=reason, paused_by=by)
+        console.print(
+            f"[yellow]paused[/] track={state.track_id} reason={state.reason!r} "
+            f"by={state.paused_by!r} at={state.paused_at!s}"
+        )
+
+
+@track_app.command("resume")
+def track_resume(
+    track_id: str = typer.Argument(..., help="track_id to resume."),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Resume a previously-paused track."""
+
+    from stockripper.db.repository import Repository
+
+    factory = _kill_switch_factory(database_url)
+    with session_scope(factory) as session:
+        repo = Repository(session)
+        state = repo.resume_track(track_id=track_id)
+        console.print(
+            f"[green]resumed[/] track={state.track_id} updated_at={state.updated_at!s}"
+        )
+
+
+@track_app.command("status")
+def track_status(
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Print all known pause state rows."""
+
+    from stockripper.db.repository import Repository
+
+    factory = _kill_switch_factory(database_url)
+    with session_scope(factory) as session:
+        repo = Repository(session)
+        rows = repo.list_track_pause_states()
+    if not rows:
+        console.print("[dim]No pause state rows recorded.[/dim]")
+        return
+    table = Table(title="Track pause state")
+    table.add_column("track_id", style="bold cyan")
+    table.add_column("paused", justify="center")
+    table.add_column("reason")
+    table.add_column("by")
+    table.add_column("paused_at")
+    table.add_column("updated_at")
+    for row in rows:
+        table.add_row(
+            row.track_id,
+            "[red]✓[/]" if row.paused else "[green]✗[/]",
+            (row.reason or "") if row.paused else "",
+            row.paused_by or "",
+            str(row.paused_at) if row.paused_at else "",
+            str(row.updated_at),
+        )
+    console.print(table)
+
+
+# ---------------------------------------------------------------------------
+# Multi-track window runner
+# ---------------------------------------------------------------------------
+@agents_app.command("run-window")
+def agents_run_window(
+    track: list[str] = typer.Option(  # noqa: B008 - typer pattern
+        [], "--track", "-t",
+        help="Restrict to specific track_ids. Defaults to every enabled track.",
+    ),
+    symbol: list[str] = typer.Option(  # noqa: B008 - typer pattern
+        ["SPY"], "--symbol", "-s",
+        help="One or more symbols. The runner fans out (track x symbol) in parallel.",
+    ),
+    window_label: str = typer.Option(
+        "adhoc", "--window-label", help="Window label (e.g. opening, midday, close).",
+    ),
+    fake: bool = typer.Option(
+        True, "--fake/--no-fake",
+        help="Use the offline CannedCouncilLLM. Pass --no-fake to call real OpenAI.",
+    ),
+    persist: bool = typer.Option(
+        True, "--persist/--no-persist",
+        help="When --persist, write run/track/agent rows to the DB (default).",
+    ),
+    seed: int | None = typer.Option(
+        None, "--seed", help="rng_seed propagated to every agent run.",
+    ),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Run every (track, symbol) pair in parallel via the Strategy Tracks Manager.
+
+    Honors the global kill-switch and per-track pause state. Without
+    ``--persist`` no DB writes happen — useful for offline demos.
+    """
+
+    from sqlalchemy.orm import sessionmaker
+
+    from stockripper.agents.llm import LLMClient, OpenAIStructuredClient
+    from stockripper.agents.registry import build_registry
+    from stockripper.agents.window_runner import run_window
+
+    registry = build_registry()
+    track_ids = (
+        tuple(track) if track
+        else tuple(t.track_id for t in DEFAULT_TRACKS if t.enabled)
+    )
+    symbols = tuple(s.upper() for s in symbol)
+
+    factory = None
+    if persist:
+        engine = build_engine(database_url)
+        factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+
+    if fake:
+        console.print("[yellow]offline mode: using CannedCouncilLLM per coroutine[/yellow]")
+        llm_factory = None
+    else:
+        settings = load_settings()
+        api_key = settings.openai_api_key.get_secret_value()
+        default_model = settings.openai_model_default
+        judge_model = settings.openai_model_judge
+        for judge in registry.judges.values():
+            judge.model_id_override = judge_model
+        console.print(
+            f"[green]live mode: agents={default_model} judge={judge_model}[/green]"
+        )
+
+        def llm_factory(_packet: Any) -> LLMClient | None:
+            return OpenAIStructuredClient(
+                api_key=api_key, default_model=default_model,
+            )
+
+    async def _run_all() -> None:
+        result = await run_window(
+            registry=registry,
+            track_ids=track_ids,
+            symbols=symbols,
+            window_label=window_label,
+            rng_seed=seed,
+            persist=persist,
+            session_factory=factory,
+            llm_factory=llm_factory,
+        )
+        _print_window_result(result)
+
+    asyncio.run(_run_all())
+
+
+def _print_window_result(result: Any) -> None:
+    console.print()
+    console.print(
+        f"[bold cyan]Window run[/bold cyan] run_id={result.run_id} "
+        f"window={result.window_label} status=[bold]{result.status}[/bold] "
+        f"day={result.trading_day} "
+        f"duration={(result.completed_at - result.started_at).total_seconds():.2f}s"
+    )
+    table = Table(title=f"Per-(track,symbol) outcomes ({len(result.outcomes)})")
+    table.add_column("track_id", style="bold cyan")
+    table.add_column("symbol")
+    table.add_column("status", justify="center")
+    table.add_column("decision_items", justify="right")
+    table.add_column("notes", overflow="fold")
+    for o in result.outcomes:
+        if o.result is not None and o.result.judge_decision is not None:
+            items = str(len(o.result.judge_decision.plan.items))
+            note = o.result.judge_decision.plan.rationale[:90]
+        elif o.result is not None:
+            items = "-"
+            note = (o.result.judge_run.quarantine_reason or "")[:90]
+        else:
+            items = "-"
+            note = (o.reason or o.error or "")[:90]
+        status_text = {
+            "ok": "[green]ok[/]",
+            "partial": "[yellow]partial[/]",
+            "skipped_paused": "[blue]skipped[/]",
+            "aborted_kill": "[bold red]kill[/]",
+            "failed": "[red]failed[/]",
+        }.get(o.status, o.status)
+        table.add_row(o.track_id, o.symbol, status_text, items, note)
+    console.print(table)
+
 

--- a/src/stockripper/agents/base.py
+++ b/src/stockripper/agents/base.py
@@ -15,13 +15,13 @@ import datetime as dt
 import hashlib
 import json
 import logging
-import uuid
 from abc import ABC, abstractmethod
 from decimal import Decimal
 from typing import cast
 
 from pydantic import BaseModel, ValidationError
 
+from stockripper.agents.ids import agent_run_id as _derive_agent_run_id
 from stockripper.agents.llm import (
     LLMClient,
     StructuredResponse,
@@ -101,9 +101,15 @@ class BaseAgent[TOutput: BaseModel](ABC):
         now: dt.datetime | None = None,
     ) -> AgentRunResult:
         created_at = now if now is not None else _now()
-        run_id = f"run_{self.agent_id}_{uuid.uuid4().hex[:16]}"
         template = self.template
         _input_text, input_hash = serialize_input(payload)
+        # Deterministic AgentRunResult.run_id derived from stable inputs
+        # so replay can address agent runs idempotently.
+        run_id = _derive_agent_run_id(
+            track_run_id=payload.run_id,
+            agent_id=self.agent_id,
+            input_hash=input_hash,
+        )
         model_id_for_quarantine = self.model_id_override or "unknown"
 
         try:
@@ -171,7 +177,7 @@ class BaseAgent[TOutput: BaseModel](ABC):
                 raw_response_text=json.dumps(parsed_local.model_dump(mode="json"), default=str),
                 quarantine_reason=None,
                 latency_ms=0,
-                created_at=_now(),
+                created_at=created_at,
             )
 
         # ---- LLM path ----------------------------------------------------
@@ -237,7 +243,7 @@ class BaseAgent[TOutput: BaseModel](ABC):
             raw_response_text=response.raw_text,
             quarantine_reason=None,
             latency_ms=response.latency_ms,
-            created_at=_now(),
+            created_at=created_at,
         )
 
     # ------------------------------------------------------------------

--- a/src/stockripper/agents/canned_llm.py
+++ b/src/stockripper/agents/canned_llm.py
@@ -19,7 +19,6 @@ Design contract:
 from __future__ import annotations
 
 import datetime as dt
-import uuid
 from collections.abc import Mapping
 from decimal import Decimal
 from typing import Any, TypeVar
@@ -52,26 +51,48 @@ def _now() -> dt.datetime:
 class CannedCouncilLLM:
     """No-network ``LLMClient`` that synthesizes valid neutral outputs.
 
-    The orchestrator calls :meth:`bind_packet` before each per-packet
-    council fanout so symbol / instrument context is available when the
-    synthesizer constructs ``AgentRecommendation`` outputs.
+    The packet is provided at construction so the client is **stateless
+    and safe to share** across concurrent agent calls within one
+    (track, packet) execution. Phase-4 multi-track concurrency requires
+    one ``CannedCouncilLLM`` instance per (track, packet) coroutine,
+    which the window runner enforces.
+
+    A frozen ``clock`` is optional and used only for deterministic
+    timestamping inside synthesized outputs; tests should pass an
+    explicit value so the synthesized created_at fields are reproducible.
     """
 
     def __init__(
         self,
+        packet: EvidencePacket | None = None,
         *,
         model_id: str = "canned-council-v1",
         fixed_latency_ms: int = 1,
+        clock: dt.datetime | None = None,
     ) -> None:
         self._model_id = model_id
         self._fixed_latency_ms = fixed_latency_ms
-        self._packet: EvidencePacket | None = None
+        self._packet: EvidencePacket | None = packet
+        self._clock: dt.datetime | None = clock
         self.calls: list[Mapping[str, Any]] = []
 
     def bind_packet(self, packet: EvidencePacket) -> None:
-        """Provide per-packet context for the next batch of synthesized calls."""
+        """Provide per-packet context for the next batch of synthesized calls.
+
+        Retained for backwards compatibility; prefer passing ``packet`` in
+        the constructor. Calling this on a shared instance from multiple
+        coroutines is a race — construct a fresh client per coroutine.
+        """
 
         self._packet = packet
+
+    def bind_clock(self, clock: dt.datetime) -> None:
+        """Freeze the wall-clock used for synthesized ``created_at`` fields."""
+
+        self._clock = clock
+
+    def _moment(self) -> dt.datetime:
+        return self._clock if self._clock is not None else _now()
 
     def run_structured(
         self,
@@ -137,8 +158,10 @@ class CannedCouncilLLM:
     # ------------------------------------------------------------------
     def _make_recommendation(self, agent_id: str) -> AgentRecommendation:
         packet = self._require_packet(agent_id)
+        when = self._moment()
+        rec_seed = self._stable_id_seed(agent_id, "rec", packet.symbol)
         return AgentRecommendation(
-            recommendation_id=f"rec_{uuid.uuid4().hex[:16]}",
+            recommendation_id=f"rec_{rec_seed}",
             agent_id=agent_id,
             agent_version="1.0.0",
             track_id=packet.track_id,
@@ -156,13 +179,14 @@ class CannedCouncilLLM:
             prompt_injection_findings=(),
             multi_leg=None,
             pair_legs=None,
-            created_at=_now(),
+            created_at=when,
         )
 
     def _make_market_climate(self, agent_id: str) -> MarketClimateReport:
-        when = _now()
+        when = self._moment()
+        seed = self._stable_id_seed(agent_id, "climate", when.date().isoformat())
         return MarketClimateReport(
-            report_id=f"climate_{uuid.uuid4().hex[:16]}",
+            report_id=f"climate_{seed}",
             agent_id=agent_id,
             agent_version="1.0.0",
             as_of=when.date(),
@@ -178,31 +202,37 @@ class CannedCouncilLLM:
 
     def _make_skeptic_report(self, agent_id: str) -> SkepticReport:
         packet = self._require_packet(agent_id)
+        when = self._moment()
+        seed = self._stable_id_seed(agent_id, "skeptic", packet.symbol)
         return SkepticReport(
-            report_id=f"skeptic_{uuid.uuid4().hex[:16]}",
+            report_id=f"skeptic_{seed}",
             agent_id=agent_id,
             agent_version="1.0.0",
             track_id=packet.track_id,
             critiques=(),
-            created_at=_now(),
+            created_at=when,
         )
 
     def _make_risk_report(self, agent_id: str) -> RiskManagerReport:
         packet = self._require_packet(agent_id)
+        when = self._moment()
+        seed = self._stable_id_seed(agent_id, "risk", packet.symbol)
         return RiskManagerReport(
-            report_id=f"risk_{uuid.uuid4().hex[:16]}",
+            report_id=f"risk_{seed}",
             agent_id=agent_id,
             agent_version="1.0.0",
             track_id=packet.track_id,
             assessments=(),
             portfolio_level_flags=(),
-            created_at=_now(),
+            created_at=when,
         )
 
     def _make_judge_decision(self, agent_id: str) -> JudgeDecision:
         packet = self._require_packet(agent_id)
+        when = self._moment()
+        seed = self._stable_id_seed(agent_id, "plan", packet.symbol)
         plan = ActionPlan(
-            decision_id=f"plan_{uuid.uuid4().hex[:16]}",
+            decision_id=f"plan_{seed}",
             track_id=packet.track_id,
             judge_agent_id=agent_id,
             judge_agent_version="1.0.0",
@@ -213,25 +243,45 @@ class CannedCouncilLLM:
                 "holding cash for this window."
             ),
             objective_label="offline_canned_judge",
-            created_at=_now(),
+            created_at=when,
         )
         return JudgeDecision(plan=plan, provenance=None)
 
     def _make_pi_report(self, agent_id: str) -> PromptInjectionReport:
+        when = self._moment()
+        seed = self._stable_id_seed(agent_id, "pi")
         return PromptInjectionReport(
-            report_id=f"pi_{uuid.uuid4().hex[:16]}",
+            report_id=f"pi_{seed}",
             agent_id=agent_id,
             agent_version="1.0.0",
             findings=(),
             scanned_evidence_ids=(),
-            created_at=_now(),
+            created_at=when,
         )
 
     # ------------------------------------------------------------------
+    def _stable_id_seed(self, *parts: str) -> str:
+        """Deterministic 16-hex seed derived from caller-provided parts.
+
+        We mix in the model id + packet id so two coroutines that share a
+        Canned client by accident at least produce distinguishable ids,
+        but the same (model, packet, parts) always produces the same id.
+        """
+
+        import hashlib
+
+        body_parts: list[str] = [self._model_id]
+        if self._packet is not None:
+            body_parts.append(self._packet.packet_id)
+        body_parts.extend(parts)
+        body = "\x00".join(body_parts)
+        return hashlib.sha256(body.encode("utf-8")).hexdigest()[:16]
+
     def _require_packet(self, agent_id: str) -> EvidencePacket:
         if self._packet is None:
             raise RuntimeError(
-                f"CannedCouncilLLM: bind_packet() not called before {agent_id!r}."
+                f"CannedCouncilLLM: packet not provided (construct with "
+                f"packet=… or call bind_packet) before {agent_id!r}."
             )
         return self._packet
 

--- a/src/stockripper/agents/demo.py
+++ b/src/stockripper/agents/demo.py
@@ -36,11 +36,19 @@ def build_demo_packet(
     instrument: RecommendationInstrument = RecommendationInstrument.EQUITY,
     bucket: str = "core",
     now: dt.datetime | None = None,
+    packet_id: str | None = None,
 ) -> EvidencePacket:
-    """Build a self-contained packet for offline orchestrator demos."""
+    """Build a self-contained packet for offline orchestrator demos.
+
+    ``packet_id`` defaults to a random ``pkt_demo_*`` value for ad-hoc
+    CLI usage; the window runner overrides it with a deterministic
+    derivation from ``(track_id, window_run_id, symbol)`` so replays
+    reproduce identical ids.
+    """
 
     when = now if now is not None else _now()
     wid = window_id or when.strftime("demo-%Y%m%dT%H%M%SZ")
+    pid = packet_id if packet_id is not None else f"pkt_demo_{uuid.uuid4().hex[:12]}"
     reasons: tuple[CandidateReason, ...] = (
         CandidateReason(
             code=CandidateReasonCode.PASSES_PRICE_FLOOR,
@@ -64,7 +72,7 @@ def build_demo_packet(
         summary_bits.append(f"news30={recent_news_count_30d}")
     summary = " ".join(summary_bits) or f"symbol={symbol}"
     return EvidencePacket(
-        packet_id=f"pkt_demo_{uuid.uuid4().hex[:12]}",
+        packet_id=pid,
         track_id=track_id,
         window_id=wid,
         symbol=symbol.upper(),

--- a/src/stockripper/agents/ids.py
+++ b/src/stockripper/agents/ids.py
@@ -1,0 +1,101 @@
+"""Deterministic ID helpers for Phase-4 multi-track runs.
+
+Replay determinism requires every persisted row to have an ID derived
+from its stable inputs, not a random UUID. The helpers in this module
+all produce stable 24-hex-character suffixes from a sorted, NUL-joined
+list of components so two runs with identical inputs produce identical
+IDs.
+
+ID format is ``<prefix>_<sha256(...)[:24]>`` where prefix is one of:
+
+* ``win`` — window-level run (one per call to ``run_window``).
+* ``trk`` — one track's execution within a window.
+* ``agr`` — one agent invocation within a track-run.
+* ``rec`` — one synthesized council recommendation.
+* ``dec`` — one judge decision.
+* ``act`` — one action item inside a judge decision.
+* ``pkt`` — one evidence packet.
+
+Use the helpers below — never hand-roll the formatting.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+from typing import Final
+
+_ID_HEX_LEN: Final[int] = 24
+
+
+def _stable_digest(*parts: object) -> str:
+    body = "\x00".join("" if p is None else str(p) for p in parts)
+    return hashlib.sha256(body.encode("utf-8")).hexdigest()[:_ID_HEX_LEN]
+
+
+def window_run_id(
+    *,
+    window_label: str,
+    trading_day: dt.date,
+    config_hash: str,
+    started_at: dt.datetime,
+) -> str:
+    """Deterministic window-level run id.
+
+    ``started_at`` is included so re-running the same window twice in
+    one day still produces distinct ids. For replay-from-fixture you
+    must reuse the original ``started_at``.
+    """
+
+    return "win_" + _stable_digest(
+        window_label, trading_day.isoformat(), config_hash, started_at.isoformat()
+    )
+
+
+def track_run_id(*, window_run_id: str, track_id: str, packet_id: str) -> str:
+    """Deterministic per-(window, track, packet) execution id."""
+
+    return "trk_" + _stable_digest(window_run_id, track_id, packet_id)
+
+
+def agent_run_id(
+    *,
+    track_run_id: str,
+    agent_id: str,
+    input_hash: str,
+) -> str:
+    """Deterministic per-agent-invocation id.
+
+    Two calls to the same agent on the same input (same input_hash)
+    inside the same track-run will collide — that is intentional: the
+    persistence layer treats them as upserts.
+    """
+
+    return "agr_" + _stable_digest(track_run_id, agent_id, input_hash)
+
+
+def recommendation_id(*, agent_run_id: str, symbol: str) -> str:
+    return "rec_" + _stable_digest(agent_run_id, symbol)
+
+
+def decision_id(*, track_run_id: str, judge_agent_id: str) -> str:
+    return "dec_" + _stable_digest(track_run_id, judge_agent_id)
+
+
+def action_id(*, decision_id: str, ordinal: int, symbol: str) -> str:
+    return "act_" + _stable_digest(decision_id, ordinal, symbol)
+
+
+def packet_id(*, track_id: str, window_run_id: str, symbol: str) -> str:
+    return "pkt_" + _stable_digest(track_id, window_run_id, symbol)
+
+
+__all__ = (
+    "action_id",
+    "agent_run_id",
+    "decision_id",
+    "packet_id",
+    "recommendation_id",
+    "track_run_id",
+    "window_run_id",
+)

--- a/src/stockripper/agents/orchestrator.py
+++ b/src/stockripper/agents/orchestrator.py
@@ -1,4 +1,4 @@
-"""Phase-4 minimal-slice orchestrator.
+"""Phase-4 orchestrator.
 
 Runs one (track, packet) collaborative cycle:
 
@@ -12,18 +12,15 @@ instead of crashing the cycle. ``llm`` may be ``None`` for purely
 deterministic baseline tracks; LLM tracks require an :class:`LLMClient`
 (real ``OpenAIStructuredClient`` or the offline :class:`CannedCouncilLLM`).
 
-This is intentionally NOT LangGraph — it is the smallest useful slice
-that exercises every Phase-3 surface end-to-end so we can observe agents
-collaborating. Real graph wiring, checkpoints, persistence of
-``agent_runs`` / ``judge_decisions``, and parallel sub-graphs per track
-all land in the full Phase 4 PR.
+Phase 4 makes IDs and timestamps deterministic for replay: the caller
+passes ``window_run_id`` and a frozen ``now`` so every agent input is
+reproducible.
 """
 
 from __future__ import annotations
 
 import asyncio
 import datetime as dt
-import uuid
 from dataclasses import dataclass
 from typing import Any
 
@@ -32,8 +29,8 @@ from stockripper.agents.adversarial import (
     empty_skeptic_report,
 )
 from stockripper.agents.base import BaseAgent
-from stockripper.agents.canned_llm import CannedCouncilLLM
 from stockripper.agents.council import empty_market_climate
+from stockripper.agents.ids import track_run_id as derive_track_run_id
 from stockripper.agents.llm import LLMClient
 from stockripper.agents.registry import AgentRegistry
 from stockripper.agents.schemas import (
@@ -59,13 +56,20 @@ class TrackRunResult:
 
     track_id: str
     window_id: str
-    run_id: str
+    window_run_id: str
+    track_run_id: str
     packet: EvidencePacket
     market_climate_run: AgentRunResult | None
     council_runs: tuple[AgentRunResult, ...]
     skeptic_run: AgentRunResult | None
     risk_run: AgentRunResult | None
     judge_run: AgentRunResult
+    started_at: dt.datetime
+
+    @property
+    def run_id(self) -> str:
+        """Backwards-compat alias for ``track_run_id``."""
+        return self.track_run_id
 
     @property
     def all_runs(self) -> tuple[AgentRunResult, ...]:
@@ -138,6 +142,7 @@ class TrackRunResult:
 
 def _build_input(
     *,
+    track_run_id: str,
     track_id: str,
     window_id: str,
     agent_id: str,
@@ -150,7 +155,7 @@ def _build_input(
     now: dt.datetime,
 ) -> AgentRunInput:
     return AgentRunInput(
-        run_id=f"run_{uuid.uuid4().hex[:16]}",
+        run_id=track_run_id,
         track_id=track_id,
         window_id=window_id,
         agent_id=agent_id,
@@ -170,8 +175,9 @@ async def _run_one(
     *,
     llm: LLMClient | None,
     seed: int | None,
+    now: dt.datetime,
 ) -> AgentRunResult:
-    return await asyncio.to_thread(agent.run, payload, llm=llm, seed=seed)
+    return await asyncio.to_thread(agent.run, payload, llm=llm, seed=seed, now=now)
 
 
 async def run_track(
@@ -182,19 +188,42 @@ async def run_track(
     llm: LLMClient | None = None,
     rng_seed: int | None = None,
     window_id: str | None = None,
+    window_run_id: str | None = None,
     now: dt.datetime | None = None,
 ) -> TrackRunResult:
-    """Run one (track, packet) collaborative cycle and return all envelopes."""
+    """Run one (track, packet) collaborative cycle and return all envelopes.
+
+    ``window_run_id`` and ``now`` should be supplied by the Strategy
+    Tracks Manager (``window_runner.run_window``) so every agent input
+    in the window shares a stable wall-clock and id. Defaults work for
+    one-shot usage from the CLI but produce non-deterministic ids.
+    """
 
     when = now if now is not None else _now()
     wid = window_id or packet.window_id
     if track_id not in registry.bindings:
         raise KeyError(f"unknown track_id: {track_id!r}")
     binding = registry.bindings[track_id]
-    run_id = f"trackrun_{uuid.uuid4().hex[:16]}"
+    wrid = window_run_id or f"win_adhoc_{int(when.timestamp() * 1000):x}"
+    track_run_id = derive_track_run_id(
+        window_run_id=wrid,
+        track_id=track_id,
+        packet_id=packet.packet_id,
+    )
 
-    if isinstance(llm, CannedCouncilLLM):
-        llm.bind_packet(packet)
+    # Packet-aware fake clients (e.g. ``CannedCouncilLLM``) expose
+    # ``bind_packet`` so they can synthesize symbol-correct outputs.
+    # Binding inside ``run_track`` is safe because this coroutine
+    # owns the client end-to-end. The window runner is responsible
+    # for handing every concurrent ``run_track`` invocation its own
+    # client instance to avoid cross-coroutine races.
+    if llm is not None:
+        bind_packet = getattr(llm, "bind_packet", None)
+        if callable(bind_packet):
+            bind_packet(packet)
+        bind_clock = getattr(llm, "bind_clock", None)
+        if callable(bind_clock):
+            bind_clock(when)
 
     # ------------------------------------------------------------------
     # Step 1: market climate (LLM tracks only).
@@ -203,6 +232,7 @@ async def run_track(
     climate_for_council: MarketClimateReport | None = None
     if binding.market_climate_enabled:
         mc_input = _build_input(
+            track_run_id=track_run_id,
             track_id=track_id,
             window_id=wid,
             agent_id=registry.market_climate.agent_id,
@@ -211,7 +241,7 @@ async def run_track(
             now=when,
         )
         climate_run = await _run_one(
-            registry.market_climate, mc_input, llm=llm, seed=rng_seed
+            registry.market_climate, mc_input, llm=llm, seed=rng_seed, now=when
         )
         if (
             climate_run.status == AgentRunStatus.OK
@@ -227,6 +257,7 @@ async def run_track(
     council_agents = registry.council_for(track_id)
     council_inputs = [
         _build_input(
+            track_run_id=track_run_id,
             track_id=track_id,
             window_id=wid,
             agent_id=agent.agent_id,
@@ -240,7 +271,7 @@ async def run_track(
     council_runs = tuple(
         await asyncio.gather(
             *(
-                _run_one(agent, payload, llm=llm, seed=rng_seed)
+                _run_one(agent, payload, llm=llm, seed=rng_seed, now=when)
                 for agent, payload in zip(
                     council_agents, council_inputs, strict=True
                 )
@@ -263,6 +294,7 @@ async def run_track(
     risk_for_judge: RiskManagerReport | None = None
     if binding.is_llm_track and binding.adversarial_agent_ids:
         skeptic_input = _build_input(
+            track_run_id=track_run_id,
             track_id=track_id,
             window_id=wid,
             agent_id=registry.skeptic.agent_id,
@@ -273,6 +305,7 @@ async def run_track(
             now=when,
         )
         risk_input = _build_input(
+            track_run_id=track_run_id,
             track_id=track_id,
             window_id=wid,
             agent_id=registry.risk_manager.agent_id,
@@ -283,8 +316,8 @@ async def run_track(
             now=when,
         )
         skeptic_result, risk_result = await asyncio.gather(
-            _run_one(registry.skeptic, skeptic_input, llm=llm, seed=rng_seed),
-            _run_one(registry.risk_manager, risk_input, llm=llm, seed=rng_seed),
+            _run_one(registry.skeptic, skeptic_input, llm=llm, seed=rng_seed, now=when),
+            _run_one(registry.risk_manager, risk_input, llm=llm, seed=rng_seed, now=when),
         )
         skeptic_run = skeptic_result
         risk_run = risk_result
@@ -308,6 +341,7 @@ async def run_track(
     # ------------------------------------------------------------------
     judge_agent = registry.judge_for(track_id)
     judge_input = _build_input(
+        track_run_id=track_run_id,
         track_id=track_id,
         window_id=wid,
         agent_id=judge_agent.agent_id,
@@ -320,18 +354,22 @@ async def run_track(
         now=when,
     )
     judge_llm = llm if judge_agent.requires_llm else None
-    judge_run = await _run_one(judge_agent, judge_input, llm=judge_llm, seed=rng_seed)
+    judge_run = await _run_one(
+        judge_agent, judge_input, llm=judge_llm, seed=rng_seed, now=when
+    )
 
     return TrackRunResult(
         track_id=track_id,
         window_id=wid,
-        run_id=run_id,
+        window_run_id=wrid,
+        track_run_id=track_run_id,
         packet=packet,
         market_climate_run=climate_run,
         council_runs=council_runs,
         skeptic_run=skeptic_run,
         risk_run=risk_run,
         judge_run=judge_run,
+        started_at=when,
     )
 
 

--- a/src/stockripper/agents/persistence.py
+++ b/src/stockripper/agents/persistence.py
@@ -1,0 +1,215 @@
+"""Phase-4 persistence translator.
+
+Converts a :class:`TrackRunResult` produced by ``run_track`` into rows in
+``track_runs`` / ``agent_runs`` / ``recommendations`` / ``judge_decisions``
+/ ``decision_actions`` tables.
+
+The window runner (``run_window``) calls :func:`persist_track_run` once
+per completed (or skipped) track inside its own transaction so a failure
+on one track does not roll back another track's audit trail.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from typing import Any
+
+from stockripper.agents.orchestrator import TrackRunResult
+from stockripper.agents.schemas import (
+    ActionPlan,
+    AgentRecommendation,
+    AgentRunResult,
+    AgentRunStatus,
+    JudgeDecision,
+    action_item_to_ledger_row,
+    recommendation_to_ledger_row,
+)
+from stockripper.db.repository import Repository
+
+
+def _output_schema_name(result: AgentRunResult) -> str:
+    if result.output is not None:
+        return type(result.output).__name__
+    return "Unknown"
+
+
+def _output_json(result: AgentRunResult) -> dict[str, Any] | None:
+    if result.output is None:
+        return None
+    return result.output.model_dump(mode="json")
+
+
+def persist_track_run(
+    repo: Repository,
+    *,
+    run_id: str,
+    result: TrackRunResult,
+    completed_at: dt.datetime,
+) -> None:
+    """Persist a successful (or partial) track run.
+
+    Writes the TrackRun envelope, one AgentRun per envelope, recommendation
+    rows for OK council outputs, and judge decision + decision actions when
+    the judge ran successfully. Idempotent: re-running with identical
+    deterministic ids upserts existing rows.
+
+    Caller controls the transaction boundary; this function only stages
+    inserts/updates on the session.
+    """
+
+    has_quarantine = any(
+        r.status == AgentRunStatus.QUARANTINED for r in result.all_runs
+    )
+    track_run_status = "partial" if has_quarantine else "ok"
+
+    repo.upsert_track_run(
+        track_run_id=result.track_run_id,
+        run_id=run_id,
+        track_id=result.track_id,
+        packet_id=result.packet.packet_id,
+        symbol=result.packet.symbol,
+        status=track_run_status,
+        started_at=result.started_at,
+        completed_at=completed_at,
+    )
+
+    for envelope in result.all_runs:
+        _persist_agent_run(
+            repo,
+            run_id=run_id,
+            track_run_id=result.track_run_id,
+            track_id=result.track_id,
+            envelope=envelope,
+        )
+
+    for envelope in result.council_runs:
+        if envelope.status == AgentRunStatus.OK and isinstance(
+            envelope.output, AgentRecommendation
+        ):
+            row = recommendation_to_ledger_row(envelope.output)
+            row["run_id"] = run_id
+            repo.upsert_recommendation(**row)
+
+    decision = result.judge_decision
+    if decision is not None:
+        _persist_judge_decision(repo, run_id=run_id, decision=decision)
+
+
+def persist_skipped_track(
+    repo: Repository,
+    *,
+    run_id: str,
+    track_run_id: str,
+    track_id: str,
+    packet_id: str,
+    symbol: str,
+    started_at: dt.datetime,
+    reason: str,
+    status: str = "skipped_paused",
+) -> None:
+    """Write a TrackRun marker for a (track, packet) that did not execute."""
+
+    repo.upsert_track_run(
+        track_run_id=track_run_id,
+        run_id=run_id,
+        track_id=track_id,
+        packet_id=packet_id,
+        symbol=symbol,
+        status=status,
+        started_at=started_at,
+        completed_at=started_at,
+        interrupt_reason=reason,
+    )
+
+
+def persist_failed_track(
+    repo: Repository,
+    *,
+    run_id: str,
+    track_run_id: str,
+    track_id: str,
+    packet_id: str,
+    symbol: str,
+    started_at: dt.datetime,
+    completed_at: dt.datetime,
+    reason: str,
+) -> None:
+    """Write a TrackRun marker when ``run_track`` itself raised."""
+
+    repo.upsert_track_run(
+        track_run_id=track_run_id,
+        run_id=run_id,
+        track_id=track_id,
+        packet_id=packet_id,
+        symbol=symbol,
+        status="failed",
+        started_at=started_at,
+        completed_at=completed_at,
+        interrupt_reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+def _persist_agent_run(
+    repo: Repository,
+    *,
+    run_id: str,
+    track_run_id: str,
+    track_id: str,
+    envelope: AgentRunResult,
+) -> None:
+    fingerprint = envelope.fingerprint
+    repo.upsert_agent_run(
+        agent_run_id=envelope.run_id,
+        track_run_id=track_run_id,
+        run_id=run_id,
+        track_id=track_id,
+        agent_id=envelope.agent_id,
+        agent_version=envelope.agent_version,
+        output_schema_name=_output_schema_name(envelope),
+        status=envelope.status.value,
+        fingerprint_digest=fingerprint.digest,
+        model_id=fingerprint.model_id,
+        seed=fingerprint.seed,
+        prompt_content_hash=fingerprint.prompt_content_hash,
+        schema_content_hash=fingerprint.schema_content_hash,
+        input_content_hash=fingerprint.input_content_hash,
+        output_json=_output_json(envelope),
+        raw_response_text=envelope.raw_response_text,
+        quarantine_reason=envelope.quarantine_reason,
+        latency_ms=envelope.latency_ms,
+        started_at=envelope.created_at,
+        created_at=envelope.created_at,
+    )
+
+
+def _persist_judge_decision(
+    repo: Repository,
+    *,
+    run_id: str,
+    decision: JudgeDecision,
+) -> None:
+    plan: ActionPlan = decision.plan
+    repo.upsert_judge_decision(
+        decision_id=plan.decision_id,
+        run_id=run_id,
+        track_id=plan.track_id,
+        judge_agent_id=plan.judge_agent_id,
+        portfolio_posture=plan.portfolio_posture.value,
+        raw_output_uri=None,
+        created_at=plan.created_at,
+    )
+    for item in plan.items:
+        row = action_item_to_ledger_row(item, decision_id=plan.decision_id)
+        # ``decision_actions`` does not have a ``risk_status`` value yet
+        # (Phase 5 will populate it from the risk gate); leave it null.
+        repo.upsert_decision_action(**row)
+
+
+__all__ = (
+    "persist_failed_track",
+    "persist_skipped_track",
+    "persist_track_run",
+)

--- a/src/stockripper/agents/window_runner.py
+++ b/src/stockripper/agents/window_runner.py
@@ -1,0 +1,559 @@
+"""Phase-4 Strategy Tracks Manager.
+
+``run_window`` is the multi-track entry point. It fans out per-track
+collaborative cycles in parallel, honors the global kill-switch and
+per-track pause state, isolates failures so one bad track does not
+kill the window, and persists per-track audit trails transactionally
+so a failure inside persistence for one track does not roll back
+another track's data.
+
+Spec acceptance (§25 Phase 4): *End-to-end workflow runs all enabled
+tracks in parallel with mocked execution; replay reproduces decisions.*
+"""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import logging
+from dataclasses import dataclass, field
+from typing import Final
+
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import Session
+
+from stockripper.agents.canned_llm import CannedCouncilLLM
+from stockripper.agents.demo import build_demo_packet
+from stockripper.agents.ids import (
+    packet_id as derive_packet_id,
+)
+from stockripper.agents.ids import (
+    track_run_id as derive_track_run_id,
+)
+from stockripper.agents.ids import (
+    window_run_id as derive_window_run_id,
+)
+from stockripper.agents.llm import LLMClient
+from stockripper.agents.orchestrator import TrackRunResult, run_track
+from stockripper.agents.persistence import (
+    persist_failed_track,
+    persist_skipped_track,
+    persist_track_run,
+)
+from stockripper.agents.registry import AgentRegistry
+from stockripper.agents.schemas import EvidencePacket
+from stockripper.db.engine import build_session_factory, session_scope
+from stockripper.db.repository import Repository
+
+LOG: Final = logging.getLogger(__name__)
+
+_KILL_REASON_PREFIX: Final = "kill_switch_engaged"
+_PAUSED_REASON_PREFIX: Final = "track_paused"
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+@dataclass(frozen=True)
+class TrackOutcome:
+    """One entry in :class:`WindowRunResult.outcomes`."""
+
+    track_id: str
+    symbol: str
+    packet_id: str
+    track_run_id: str
+    status: str
+    """One of: ok, partial, skipped_paused, aborted_kill, failed."""
+    reason: str | None = None
+    result: TrackRunResult | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class WindowRunResult:
+    """Aggregate output of one :func:`run_window` call."""
+
+    run_id: str
+    window_label: str
+    trading_day: dt.date
+    started_at: dt.datetime
+    completed_at: dt.datetime
+    status: str
+    """One of: ok, partial, aborted_kill, failed."""
+    outcomes: tuple[TrackOutcome, ...] = field(default_factory=tuple)
+
+    @property
+    def ok_outcomes(self) -> tuple[TrackOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.status == "ok")
+
+    @property
+    def skipped_outcomes(self) -> tuple[TrackOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.status == "skipped_paused")
+
+    @property
+    def aborted_outcomes(self) -> tuple[TrackOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.status == "aborted_kill")
+
+    @property
+    def failed_outcomes(self) -> tuple[TrackOutcome, ...]:
+        return tuple(o for o in self.outcomes if o.status == "failed")
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+async def run_window(
+    *,
+    registry: AgentRegistry,
+    track_ids: tuple[str, ...],
+    symbols: tuple[str, ...],
+    window_label: str = "adhoc",
+    trading_day: dt.date | None = None,
+    config_hash: str = "dev",
+    rng_seed: int | None = None,
+    now: dt.datetime | None = None,
+    llm_factory: LLMClientFactory | None = None,
+    persist: bool = True,
+    session_factory: sessionmaker[Session] | None = None,
+    packet_builder: PacketBuilder | None = None,
+) -> WindowRunResult:
+    """Run every enabled (track, symbol) pair in parallel.
+
+    Parameters
+    ----------
+    registry:
+        Pre-built :class:`AgentRegistry` from :func:`build_registry`.
+    track_ids, symbols:
+        Cartesian product becomes the (track, symbol) work list.
+    window_label, trading_day, config_hash:
+        Inputs to the deterministic ``run_id`` derivation. Re-running
+        with identical values reuses the same ``run_id`` (upsert).
+    rng_seed:
+        Threaded into every agent call.
+    now:
+        Frozen wall-clock for the entire window. **Required for replay
+        determinism.** Defaults to ``_utcnow()`` for ad-hoc runs.
+    llm_factory:
+        Callable that returns a fresh ``LLMClient`` per (track, symbol)
+        coroutine. Defaults to a :class:`CannedCouncilLLM` factory so
+        the window can run offline. Pass an OpenAI-backed factory for
+        live LLM calls.
+    persist:
+        When True, opens a session via ``session_factory`` (or the
+        default factory) and writes window/track/agent rows.
+    session_factory:
+        Override for tests; defaults to :func:`build_session_factory`.
+    packet_builder:
+        Override for tests; defaults to a wrapper around
+        :func:`build_demo_packet` that injects a deterministic
+        ``packet_id``.
+    """
+
+    when = now if now is not None else _utcnow()
+    day = trading_day if trading_day is not None else when.date()
+    run_id = derive_window_run_id(
+        window_label=window_label,
+        trading_day=day,
+        config_hash=config_hash,
+        started_at=when,
+    )
+
+    factory = llm_factory if llm_factory is not None else _default_canned_factory
+    pb = packet_builder if packet_builder is not None else _default_packet_builder
+
+    # Pre-flight: open session for control-plane reads + run row creation.
+    paused_track_ids: frozenset[str] = frozenset()
+    kill_engaged = False
+    kill_reason: str | None = None
+    if persist:
+        fac = session_factory if session_factory is not None else build_session_factory()
+        with session_scope(fac) as session:
+            repo = Repository(session)
+            repo.create_run(
+                run_id=run_id,
+                window_label=window_label,
+                trading_day=day,
+                config_hash=config_hash,
+                started_at=when,
+            )
+            kill = repo.get_kill_switch()
+            kill_engaged = kill.engaged
+            kill_reason = kill.reason
+            paused_track_ids = frozenset(repo.list_paused_track_ids())
+
+    # Build the work list now so we can record skipped/aborted markers
+    # for every (track, symbol) pair even when nothing runs.
+    work_items: list[_WorkItem] = []
+    for track_id in track_ids:
+        if track_id not in registry.bindings:
+            LOG.warning("run_window: skipping unknown track_id=%s", track_id)
+            continue
+        for symbol in symbols:
+            pid = derive_packet_id(
+                track_id=track_id, window_run_id=run_id, symbol=symbol,
+            )
+            trid = derive_track_run_id(
+                window_run_id=run_id, track_id=track_id, packet_id=pid,
+            )
+            work_items.append(
+                _WorkItem(
+                    track_id=track_id,
+                    symbol=symbol.upper(),
+                    packet_id=pid,
+                    track_run_id=trid,
+                )
+            )
+
+    # If the kill-switch is engaged, every track is aborted up front.
+    if kill_engaged:
+        reason = f"{_KILL_REASON_PREFIX}: {kill_reason or 'unknown'}"
+        outcomes = tuple(
+            TrackOutcome(
+                track_id=w.track_id,
+                symbol=w.symbol,
+                packet_id=w.packet_id,
+                track_run_id=w.track_run_id,
+                status="aborted_kill",
+                reason=reason,
+            )
+            for w in work_items
+        )
+        if persist:
+            _persist_skipped_or_aborted(
+                outcomes=outcomes,
+                run_id=run_id,
+                started_at=when,
+                session_factory=session_factory,
+                final_run_status="aborted_kill",
+            )
+        return WindowRunResult(
+            run_id=run_id,
+            window_label=window_label,
+            trading_day=day,
+            started_at=when,
+            completed_at=_utcnow(),
+            status="aborted_kill",
+            outcomes=outcomes,
+        )
+
+    # Build coroutines for every non-paused item; collect markers for
+    # paused items separately so they get persisted up-front.
+    paused_outcomes: list[TrackOutcome] = []
+    runnable: list[_WorkItem] = []
+    for w in work_items:
+        if w.track_id in paused_track_ids:
+            paused_outcomes.append(
+                TrackOutcome(
+                    track_id=w.track_id,
+                    symbol=w.symbol,
+                    packet_id=w.packet_id,
+                    track_run_id=w.track_run_id,
+                    status="skipped_paused",
+                    reason=f"{_PAUSED_REASON_PREFIX}: {w.track_id}",
+                )
+            )
+        else:
+            runnable.append(w)
+
+    coros = [
+        _run_one_track(
+            registry=registry,
+            run_id=run_id,
+            item=w,
+            packet_builder=pb,
+            llm_factory=factory,
+            window_label=window_label,
+            when=when,
+            rng_seed=rng_seed,
+        )
+        for w in runnable
+    ]
+    gathered = await asyncio.gather(*coros, return_exceptions=True)
+
+    run_outcomes: list[TrackOutcome] = []
+    for w, raw in zip(runnable, gathered, strict=True):
+        if isinstance(raw, BaseException):
+            LOG.exception(
+                "run_window: track %s/%s raised", w.track_id, w.symbol,
+                exc_info=raw,
+            )
+            run_outcomes.append(
+                TrackOutcome(
+                    track_id=w.track_id,
+                    symbol=w.symbol,
+                    packet_id=w.packet_id,
+                    track_run_id=w.track_run_id,
+                    status="failed",
+                    error=repr(raw),
+                )
+            )
+            continue
+        result: TrackRunResult = raw
+        status = (
+            "partial"
+            if any(r.status.value == "quarantined" for r in result.all_runs)
+            else "ok"
+        )
+        run_outcomes.append(
+            TrackOutcome(
+                track_id=w.track_id,
+                symbol=w.symbol,
+                packet_id=w.packet_id,
+                track_run_id=w.track_run_id,
+                status=status,
+                result=result,
+            )
+        )
+
+    # Mid-window kill-switch re-check: if engaged between pre-flight and
+    # now, mark this window aborted_kill but still keep the outcomes we
+    # already produced (they ran before the engage).
+    final_kill_engaged = False
+    final_kill_reason: str | None = None
+    if persist:
+        fac2 = session_factory if session_factory is not None else build_session_factory()
+        with session_scope(fac2) as session:
+            repo = Repository(session)
+            kill = repo.get_kill_switch()
+            final_kill_engaged = kill.engaged
+            final_kill_reason = kill.reason
+
+    all_outcomes = tuple(paused_outcomes + run_outcomes)
+    final_status = _aggregate_status(
+        all_outcomes,
+        post_run_kill_engaged=final_kill_engaged,
+        pre_run_kill_engaged=kill_engaged,
+    )
+
+    completed_at = _utcnow()
+
+    if persist:
+        _persist_window_outcomes(
+            outcomes=all_outcomes,
+            run_id=run_id,
+            started_at=when,
+            completed_at=completed_at,
+            session_factory=session_factory,
+            final_run_status=final_status,
+            post_run_kill_reason=final_kill_reason
+            if final_kill_engaged and not kill_engaged
+            else None,
+        )
+
+    return WindowRunResult(
+        run_id=run_id,
+        window_label=window_label,
+        trading_day=day,
+        started_at=when,
+        completed_at=completed_at,
+        status=final_status,
+        outcomes=all_outcomes,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+from collections.abc import Callable  # noqa: E402  (kept near consumers for clarity)
+
+LLMClientFactory = Callable[[EvidencePacket], LLMClient | None]
+PacketBuilder = Callable[..., EvidencePacket]
+
+
+@dataclass(frozen=True)
+class _WorkItem:
+    track_id: str
+    symbol: str
+    packet_id: str
+    track_run_id: str
+
+
+def _default_canned_factory(packet: EvidencePacket) -> LLMClient:
+    return CannedCouncilLLM(packet=packet)
+
+
+def _default_packet_builder(
+    *,
+    symbol: str,
+    track_id: str,
+    window_id: str,
+    packet_id: str,
+    now: dt.datetime,
+) -> EvidencePacket:
+    return build_demo_packet(
+        symbol=symbol,
+        track_id=track_id,
+        window_id=window_id,
+        packet_id=packet_id,
+        now=now,
+    )
+
+
+async def _run_one_track(
+    *,
+    registry: AgentRegistry,
+    run_id: str,
+    item: _WorkItem,
+    packet_builder: PacketBuilder,
+    llm_factory: LLMClientFactory,
+    window_label: str,
+    when: dt.datetime,
+    rng_seed: int | None,
+) -> TrackRunResult:
+    packet = packet_builder(
+        symbol=item.symbol,
+        track_id=item.track_id,
+        window_id=window_label,
+        packet_id=item.packet_id,
+        now=when,
+    )
+    llm = llm_factory(packet)
+    return await run_track(
+        registry=registry,
+        track_id=item.track_id,
+        packet=packet,
+        llm=llm,
+        rng_seed=rng_seed,
+        window_id=window_label,
+        window_run_id=run_id,
+        now=when,
+    )
+
+
+def _aggregate_status(
+    outcomes: tuple[TrackOutcome, ...],
+    *,
+    post_run_kill_engaged: bool,
+    pre_run_kill_engaged: bool,
+) -> str:
+    if post_run_kill_engaged and not pre_run_kill_engaged:
+        return "aborted_kill"
+    if any(o.status == "failed" for o in outcomes):
+        return "partial" if any(o.status == "ok" for o in outcomes) else "failed"
+    if any(o.status == "partial" for o in outcomes):
+        return "partial"
+    return "ok"
+
+
+def _persist_skipped_or_aborted(
+    *,
+    outcomes: tuple[TrackOutcome, ...],
+    run_id: str,
+    started_at: dt.datetime,
+    session_factory: sessionmaker[Session] | None,
+    final_run_status: str,
+) -> None:
+    fac = session_factory if session_factory is not None else build_session_factory()
+    for o in outcomes:
+        try:
+            with session_scope(fac) as session:
+                repo = Repository(session)
+                persist_skipped_track(
+                    repo,
+                    run_id=run_id,
+                    track_run_id=o.track_run_id,
+                    track_id=o.track_id,
+                    packet_id=o.packet_id,
+                    symbol=o.symbol,
+                    started_at=started_at,
+                    reason=o.reason or "unknown",
+                    status=o.status,
+                )
+        except Exception:
+            LOG.exception(
+                "Failed to persist skipped/aborted marker for %s/%s",
+                o.track_id, o.symbol,
+            )
+    _finalize_run(run_id=run_id, status=final_run_status, session_factory=fac)
+
+
+def _persist_window_outcomes(
+    *,
+    outcomes: tuple[TrackOutcome, ...],
+    run_id: str,
+    started_at: dt.datetime,
+    completed_at: dt.datetime,
+    session_factory: sessionmaker[Session] | None,
+    final_run_status: str,
+    post_run_kill_reason: str | None,
+) -> None:
+    fac = session_factory if session_factory is not None else build_session_factory()
+    for o in outcomes:
+        try:
+            with session_scope(fac) as session:
+                repo = Repository(session)
+                if o.status == "skipped_paused":
+                    persist_skipped_track(
+                        repo,
+                        run_id=run_id,
+                        track_run_id=o.track_run_id,
+                        track_id=o.track_id,
+                        packet_id=o.packet_id,
+                        symbol=o.symbol,
+                        started_at=started_at,
+                        reason=o.reason or "paused",
+                        status="skipped_paused",
+                    )
+                elif o.status == "failed":
+                    persist_failed_track(
+                        repo,
+                        run_id=run_id,
+                        track_run_id=o.track_run_id,
+                        track_id=o.track_id,
+                        packet_id=o.packet_id,
+                        symbol=o.symbol,
+                        started_at=started_at,
+                        completed_at=completed_at,
+                        reason=o.error or "unknown",
+                    )
+                elif o.result is not None:
+                    persist_track_run(
+                        repo,
+                        run_id=run_id,
+                        result=o.result,
+                        completed_at=completed_at,
+                    )
+        except Exception:
+            LOG.exception(
+                "Failed to persist track run for %s/%s",
+                o.track_id, o.symbol,
+            )
+
+    notes = post_run_kill_reason
+    _finalize_run(
+        run_id=run_id,
+        status=final_run_status,
+        session_factory=fac,
+        notes=notes,
+        completed_at=completed_at,
+    )
+
+
+def _finalize_run(
+    *,
+    run_id: str,
+    status: str,
+    session_factory: sessionmaker[Session],
+    notes: str | None = None,
+    completed_at: dt.datetime | None = None,
+) -> None:
+    try:
+        with session_scope(session_factory) as session:
+            repo = Repository(session)
+            run = repo.complete_run(
+                run_id=run_id, status=status, completed_at=completed_at,
+            )
+            if notes is not None:
+                run.notes = notes
+    except Exception:
+        LOG.exception("Failed to finalize run %s", run_id)
+
+
+__all__ = (
+    "LLMClientFactory",
+    "PacketBuilder",
+    "TrackOutcome",
+    "WindowRunResult",
+    "run_window",
+)

--- a/src/stockripper/alembic/versions/20260526_phase1_ledger.py
+++ b/src/stockripper/alembic/versions/20260526_phase1_ledger.py
@@ -4,14 +4,10 @@ Revision ID: 20260526_phase1_ledger
 Revises:
 Create Date: 2026-05-26 00:00:00.000000
 
-This migration creates the entire Phase 1 ledger schema (PROJECT_SPEC.md §15)
-in a single step by delegating to ``Base.metadata.create_all``. We use this
-shortcut intentionally for the first revision: every model is brand-new, so
-there is no diff to capture, and ``create_all`` produces identical DDL on
-SQLite (tests) and PostgreSQL (production) without per-dialect drift.
-
-Subsequent migrations should use proper ``op.add_column``/``op.create_table``
-operations so they can be reviewed and replayed deterministically.
+This migration creates only the Phase-1 ledger tables (PROJECT_SPEC.md §15)
+by passing an explicit allow-list of tables to ``Base.metadata.create_all``.
+Later phases create their own tables via dedicated migrations so the schema
+history stays linear and replayable.
 """
 
 from __future__ import annotations
@@ -27,12 +23,28 @@ down_revision: str | None | Sequence[str] = None
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
+# Tables created in this revision. Add-only — never edit this list once
+# the migration ships; new tables get their own migration.
+_PHASE1_TABLES: tuple[str, ...] = (
+    "risk_policies",
+    "strategy_tracks",
+    "runs",
+    "recommendations",
+    "judge_decisions",
+    "decision_actions",
+    "orders",
+    "fills",
+    "track_snapshots",
+)
+
 
 def upgrade() -> None:
     bind = op.get_bind()
-    Base.metadata.create_all(bind=bind)
+    tables = [Base.metadata.tables[name] for name in _PHASE1_TABLES]
+    Base.metadata.create_all(bind=bind, tables=tables)
 
 
 def downgrade() -> None:
     bind = op.get_bind()
-    Base.metadata.drop_all(bind=bind)
+    tables = [Base.metadata.tables[name] for name in _PHASE1_TABLES]
+    Base.metadata.drop_all(bind=bind, tables=tables)

--- a/src/stockripper/alembic/versions/20260528_phase4_orchestrator.py
+++ b/src/stockripper/alembic/versions/20260528_phase4_orchestrator.py
@@ -1,0 +1,121 @@
+"""phase 4 orchestrator tables
+
+Revision ID: 20260528_phase4_orchestrator
+Revises: 20260526_phase1_ledger
+Create Date: 2026-05-28 00:00:00.000000
+
+Adds the four tables Phase-4 multi-track orchestration needs:
+
+* ``track_runs`` — one row per (window, track, packet) execution.
+* ``agent_runs`` — one row per agent invocation; uniform audit envelope
+  for replay and per-agent attribution.
+* ``kill_switch_state`` — singleton row holding the global kill flag.
+* ``track_pause_state`` — per-track pause flag.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260528_phase4_orchestrator"
+down_revision: str | None | Sequence[str] = "20260526_phase1_ledger"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "track_runs",
+        sa.Column("track_run_id", sa.String(64), primary_key=True),
+        sa.Column(
+            "run_id", sa.String(64),
+            sa.ForeignKey("runs.run_id"), nullable=False,
+        ),
+        sa.Column(
+            "track_id", sa.String(64),
+            sa.ForeignKey("strategy_tracks.track_id"), nullable=False,
+        ),
+        sa.Column("packet_id", sa.String(64), nullable=False),
+        sa.Column("symbol", sa.String(32), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False),
+        sa.Column("interrupt_reason", sa.String(512), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.UniqueConstraint(
+            "run_id", "track_id", "packet_id",
+            name="uq_track_runs_run_track_packet",
+        ),
+    )
+
+    op.create_table(
+        "agent_runs",
+        sa.Column("agent_run_id", sa.String(64), primary_key=True),
+        sa.Column(
+            "track_run_id", sa.String(64),
+            sa.ForeignKey("track_runs.track_run_id"), nullable=False,
+        ),
+        sa.Column(
+            "run_id", sa.String(64),
+            sa.ForeignKey("runs.run_id"), nullable=False,
+        ),
+        sa.Column(
+            "track_id", sa.String(64),
+            sa.ForeignKey("strategy_tracks.track_id"), nullable=False,
+        ),
+        sa.Column("agent_id", sa.String(64), nullable=False),
+        sa.Column("agent_version", sa.String(32), nullable=False),
+        sa.Column("output_schema_name", sa.String(64), nullable=False),
+        sa.Column("status", sa.String(32), nullable=False),
+        sa.Column("fingerprint_digest", sa.String(64), nullable=False),
+        sa.Column("model_id", sa.String(128), nullable=False),
+        sa.Column("seed", sa.Integer(), nullable=True),
+        sa.Column("prompt_content_hash", sa.String(64), nullable=False),
+        sa.Column("schema_content_hash", sa.String(64), nullable=False),
+        sa.Column("input_content_hash", sa.String(64), nullable=False),
+        sa.Column("output_json", sa.JSON(), nullable=True),
+        sa.Column("raw_response_text", sa.String(65535), nullable=True),
+        sa.Column("quarantine_reason", sa.String(2048), nullable=True),
+        sa.Column("latency_ms", sa.Integer(), nullable=True),
+        sa.Column("started_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+    op.create_table(
+        "kill_switch_state",
+        sa.Column("id", sa.Integer(), primary_key=True),
+        sa.Column(
+            "engaged", sa.Boolean(),
+            nullable=False, server_default=sa.text("0"),
+        ),
+        sa.Column("reason", sa.String(512), nullable=True),
+        sa.Column("engaged_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("engaged_by", sa.String(128), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.CheckConstraint("id = 1", name="ck_kill_switch_singleton"),
+    )
+
+    op.create_table(
+        "track_pause_state",
+        sa.Column(
+            "track_id", sa.String(64),
+            sa.ForeignKey("strategy_tracks.track_id"), primary_key=True,
+        ),
+        sa.Column(
+            "paused", sa.Boolean(),
+            nullable=False, server_default=sa.text("0"),
+        ),
+        sa.Column("reason", sa.String(512), nullable=True),
+        sa.Column("paused_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("paused_by", sa.String(128), nullable=True),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("track_pause_state")
+    op.drop_table("kill_switch_state")
+    op.drop_table("agent_runs")
+    op.drop_table("track_runs")

--- a/src/stockripper/db/__init__.py
+++ b/src/stockripper/db/__init__.py
@@ -2,30 +2,38 @@
 
 from stockripper.db.engine import build_engine, build_session_factory, session_scope
 from stockripper.db.models import (
+    AgentRun,
     Base,
     DecisionAction,
     Fill,
     JudgeDecision,
+    KillSwitchState,
     Order,
     Recommendation,
     RiskPolicy,
     Run,
     StrategyTrack,
+    TrackPauseState,
+    TrackRun,
     TrackSnapshot,
 )
 from stockripper.db.repository import Repository
 
 __all__ = (
+    "AgentRun",
     "Base",
     "DecisionAction",
     "Fill",
     "JudgeDecision",
+    "KillSwitchState",
     "Order",
     "Recommendation",
     "Repository",
     "RiskPolicy",
     "Run",
     "StrategyTrack",
+    "TrackPauseState",
+    "TrackRun",
     "TrackSnapshot",
     "build_engine",
     "build_session_factory",

--- a/src/stockripper/db/models.py
+++ b/src/stockripper/db/models.py
@@ -14,6 +14,7 @@ from typing import Any
 from sqlalchemy import (
     JSON,
     Boolean,
+    CheckConstraint,
     Date,
     DateTime,
     ForeignKey,
@@ -283,3 +284,125 @@ class TrackSnapshot(Base):
     raw_snapshot_uri: Mapped[str | None] = mapped_column(String(512), nullable=True)
 
     track: Mapped[StrategyTrack] = relationship(back_populates="snapshots")
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — agent run audit + window/track lifecycle + control-plane state
+# ---------------------------------------------------------------------------
+class TrackRun(Base):
+    """One track's execution within a window-level Run (Phase 4)."""
+
+    __tablename__ = "track_runs"
+    __table_args__ = (
+        UniqueConstraint(
+            "run_id", "track_id", "packet_id",
+            name="uq_track_runs_run_track_packet",
+        ),
+    )
+
+    track_run_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    run_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("runs.run_id"), nullable=False,
+    )
+    track_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("strategy_tracks.track_id"), nullable=False,
+    )
+    packet_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    symbol: Mapped[str] = mapped_column(String(32), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    """One of: ok, skipped_paused, aborted_kill, failed, partial."""
+    interrupt_reason: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    started_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    completed_at: Mapped[dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+
+    agent_runs: Mapped[list[AgentRun]] = relationship(
+        back_populates="track_run", cascade="all, delete-orphan",
+    )
+
+
+class AgentRun(Base):
+    """Audit record for one agent invocation within a TrackRun (Phase 4)."""
+
+    __tablename__ = "agent_runs"
+
+    agent_run_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    track_run_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("track_runs.track_run_id"), nullable=False,
+    )
+    run_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("runs.run_id"), nullable=False,
+    )
+    track_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("strategy_tracks.track_id"), nullable=False,
+    )
+    agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    agent_version: Mapped[str] = mapped_column(String(32), nullable=False)
+    output_schema_name: Mapped[str] = mapped_column(String(64), nullable=False)
+    status: Mapped[str] = mapped_column(String(32), nullable=False)
+    fingerprint_digest: Mapped[str] = mapped_column(String(64), nullable=False)
+    model_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    seed: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    prompt_content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    schema_content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    input_content_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    output_json: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    raw_response_text: Mapped[str | None] = mapped_column(
+        String(65535), nullable=True,
+    )
+    quarantine_reason: Mapped[str | None] = mapped_column(
+        String(2048), nullable=True,
+    )
+    latency_ms: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    started_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False,
+    )
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )
+
+    track_run: Mapped[TrackRun] = relationship(back_populates="agent_runs")
+
+
+class KillSwitchState(Base):
+    """Global kill-switch state. Singleton row enforced by ``id == 1``."""
+
+    __tablename__ = "kill_switch_state"
+    __table_args__ = (
+        CheckConstraint("id = 1", name="ck_kill_switch_singleton"),
+    )
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True, default=1)
+    engaged: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    reason: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    engaged_at: Mapped[dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    engaged_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )
+
+
+class TrackPauseState(Base):
+    """Per-track pause state. One row per track that has ever been paused."""
+
+    __tablename__ = "track_pause_state"
+
+    track_id: Mapped[str] = mapped_column(
+        String(64),
+        ForeignKey("strategy_tracks.track_id"),
+        primary_key=True,
+    )
+    paused: Mapped[bool] = mapped_column(Boolean, nullable=False, default=False)
+    reason: Mapped[str | None] = mapped_column(String(512), nullable=True)
+    paused_at: Mapped[dt.datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True,
+    )
+    paused_by: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    updated_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )

--- a/src/stockripper/db/repository.py
+++ b/src/stockripper/db/repository.py
@@ -16,12 +16,24 @@ from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 from stockripper.db.models import (
+    AgentRun,
+    DecisionAction,
     Fill,
+    JudgeDecision,
+    KillSwitchState,
     Order,
+    Recommendation,
     RiskPolicy,
+    Run,
     StrategyTrack,
+    TrackPauseState,
+    TrackRun,
     TrackSnapshot,
 )
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
 
 
 class Repository:
@@ -232,6 +244,301 @@ class Repository:
             .limit(1)
         )
         return self.session.execute(stmt).scalar_one_or_none()
+
+    # ------------------------------------------------------------------
+    # Phase 4 — window run + track/agent audit
+    # ------------------------------------------------------------------
+    def create_run(
+        self,
+        *,
+        run_id: str,
+        window_label: str,
+        trading_day: dt.date,
+        config_hash: str,
+        started_at: dt.datetime,
+        status: str = "running",
+        notes: str | None = None,
+    ) -> Run:
+        existing = self.session.get(Run, run_id)
+        if existing is not None:
+            return existing
+        run = Run(
+            run_id=run_id,
+            window_label=window_label,
+            trading_day=trading_day,
+            config_hash=config_hash,
+            started_at=started_at,
+            status=status,
+            notes=notes,
+        )
+        self.session.add(run)
+        self.session.flush()
+        return run
+
+    def complete_run(
+        self,
+        *,
+        run_id: str,
+        status: str,
+        completed_at: dt.datetime | None = None,
+    ) -> Run:
+        run = self.session.get(Run, run_id)
+        if run is None:
+            raise KeyError(f"unknown run_id: {run_id!r}")
+        run.status = status
+        run.completed_at = completed_at if completed_at is not None else _utcnow()
+        self.session.flush()
+        return run
+
+    def get_run(self, run_id: str) -> Run | None:
+        return self.session.get(Run, run_id)
+
+    def upsert_track_run(
+        self,
+        *,
+        track_run_id: str,
+        run_id: str,
+        track_id: str,
+        packet_id: str,
+        symbol: str,
+        status: str,
+        started_at: dt.datetime,
+        completed_at: dt.datetime | None = None,
+        interrupt_reason: str | None = None,
+    ) -> TrackRun:
+        existing = self.session.get(TrackRun, track_run_id)
+        if existing is not None:
+            existing.status = status
+            existing.completed_at = completed_at
+            existing.interrupt_reason = interrupt_reason
+            return existing
+        track_run = TrackRun(
+            track_run_id=track_run_id,
+            run_id=run_id,
+            track_id=track_id,
+            packet_id=packet_id,
+            symbol=symbol,
+            status=status,
+            started_at=started_at,
+            completed_at=completed_at,
+            interrupt_reason=interrupt_reason,
+        )
+        self.session.add(track_run)
+        self.session.flush()
+        return track_run
+
+    def list_track_runs(self, *, run_id: str) -> list[TrackRun]:
+        stmt = (
+            select(TrackRun)
+            .where(TrackRun.run_id == run_id)
+            .order_by(TrackRun.track_id, TrackRun.packet_id)
+        )
+        return list(self.session.execute(stmt).scalars())
+
+    def upsert_agent_run(
+        self,
+        *,
+        agent_run_id: str,
+        track_run_id: str,
+        run_id: str,
+        track_id: str,
+        agent_id: str,
+        agent_version: str,
+        output_schema_name: str,
+        status: str,
+        fingerprint_digest: str,
+        model_id: str,
+        seed: int | None,
+        prompt_content_hash: str,
+        schema_content_hash: str,
+        input_content_hash: str,
+        output_json: dict[str, Any] | None,
+        raw_response_text: str | None,
+        quarantine_reason: str | None,
+        latency_ms: int | None,
+        started_at: dt.datetime,
+        created_at: dt.datetime,
+    ) -> AgentRun:
+        existing = self.session.get(AgentRun, agent_run_id)
+        if existing is not None:
+            existing.status = status
+            existing.output_json = output_json
+            existing.raw_response_text = raw_response_text
+            existing.quarantine_reason = quarantine_reason
+            existing.latency_ms = latency_ms
+            existing.created_at = created_at
+            return existing
+        agent_run = AgentRun(
+            agent_run_id=agent_run_id,
+            track_run_id=track_run_id,
+            run_id=run_id,
+            track_id=track_id,
+            agent_id=agent_id,
+            agent_version=agent_version,
+            output_schema_name=output_schema_name,
+            status=status,
+            fingerprint_digest=fingerprint_digest,
+            model_id=model_id,
+            seed=seed,
+            prompt_content_hash=prompt_content_hash,
+            schema_content_hash=schema_content_hash,
+            input_content_hash=input_content_hash,
+            output_json=output_json,
+            raw_response_text=raw_response_text,
+            quarantine_reason=quarantine_reason,
+            latency_ms=latency_ms,
+            started_at=started_at,
+            created_at=created_at,
+        )
+        self.session.add(agent_run)
+        self.session.flush()
+        return agent_run
+
+    def upsert_recommendation(self, **values: Any) -> Recommendation:
+        rid = str(values["recommendation_id"])
+        existing = self.session.get(Recommendation, rid)
+        if existing is not None:
+            for k, v in values.items():
+                setattr(existing, k, v)
+            return existing
+        rec = Recommendation(**values)
+        self.session.add(rec)
+        self.session.flush()
+        return rec
+
+    def upsert_judge_decision(self, **values: Any) -> JudgeDecision:
+        did = str(values["decision_id"])
+        existing = self.session.get(JudgeDecision, did)
+        if existing is not None:
+            for k, v in values.items():
+                setattr(existing, k, v)
+            return existing
+        decision = JudgeDecision(**values)
+        self.session.add(decision)
+        self.session.flush()
+        return decision
+
+    def upsert_decision_action(self, **values: Any) -> DecisionAction:
+        aid = str(values["action_id"])
+        existing = self.session.get(DecisionAction, aid)
+        if existing is not None:
+            for k, v in values.items():
+                setattr(existing, k, v)
+            return existing
+        action = DecisionAction(**values)
+        self.session.add(action)
+        self.session.flush()
+        return action
+
+    # ------------------------------------------------------------------
+    # Phase 4 — control-plane state (kill switch + per-track pause)
+    # ------------------------------------------------------------------
+    def get_kill_switch(self) -> KillSwitchState:
+        existing = self.session.get(KillSwitchState, 1)
+        if existing is not None:
+            return existing
+        row = KillSwitchState(
+            id=1, engaged=False, reason=None, engaged_at=None, engaged_by=None,
+            updated_at=_utcnow(),
+        )
+        self.session.add(row)
+        self.session.flush()
+        return row
+
+    def engage_kill_switch(
+        self, *, reason: str, engaged_by: str | None = None,
+        when: dt.datetime | None = None,
+    ) -> KillSwitchState:
+        state = self.get_kill_switch()
+        moment = when if when is not None else _utcnow()
+        state.engaged = True
+        state.reason = reason
+        state.engaged_at = moment
+        state.engaged_by = engaged_by
+        state.updated_at = moment
+        self.session.flush()
+        return state
+
+    def release_kill_switch(
+        self, *, when: dt.datetime | None = None,
+    ) -> KillSwitchState:
+        state = self.get_kill_switch()
+        moment = when if when is not None else _utcnow()
+        state.engaged = False
+        state.reason = None
+        state.engaged_at = None
+        state.engaged_by = None
+        state.updated_at = moment
+        self.session.flush()
+        return state
+
+    def get_track_pause(self, track_id: str) -> TrackPauseState | None:
+        return self.session.get(TrackPauseState, track_id)
+
+    def pause_track(
+        self, *, track_id: str, reason: str,
+        paused_by: str | None = None,
+        when: dt.datetime | None = None,
+    ) -> TrackPauseState:
+        moment = when if when is not None else _utcnow()
+        existing = self.session.get(TrackPauseState, track_id)
+        if existing is not None:
+            existing.paused = True
+            existing.reason = reason
+            existing.paused_at = moment
+            existing.paused_by = paused_by
+            existing.updated_at = moment
+            self.session.flush()
+            return existing
+        row = TrackPauseState(
+            track_id=track_id,
+            paused=True,
+            reason=reason,
+            paused_at=moment,
+            paused_by=paused_by,
+            updated_at=moment,
+        )
+        self.session.add(row)
+        self.session.flush()
+        return row
+
+    def resume_track(
+        self, *, track_id: str,
+        when: dt.datetime | None = None,
+    ) -> TrackPauseState:
+        moment = when if when is not None else _utcnow()
+        existing = self.session.get(TrackPauseState, track_id)
+        if existing is None:
+            row = TrackPauseState(
+                track_id=track_id,
+                paused=False,
+                reason=None,
+                paused_at=None,
+                paused_by=None,
+                updated_at=moment,
+            )
+            self.session.add(row)
+            self.session.flush()
+            return row
+        existing.paused = False
+        existing.reason = None
+        existing.paused_at = None
+        existing.paused_by = None
+        existing.updated_at = moment
+        self.session.flush()
+        return existing
+
+    def list_paused_track_ids(self) -> list[str]:
+        stmt = (
+            select(TrackPauseState.track_id)
+            .where(TrackPauseState.paused.is_(True))
+            .order_by(TrackPauseState.track_id)
+        )
+        return list(self.session.execute(stmt).scalars())
+
+    def list_track_pause_states(self) -> list[TrackPauseState]:
+        stmt = select(TrackPauseState).order_by(TrackPauseState.track_id)
+        return list(self.session.execute(stmt).scalars())
 
 
 # ----------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -55,3 +55,87 @@ def test_cli_db_init_creates_sqlite_schema(tmp_path: Path) -> None:
     assert seed.exit_code == 0, seed.stdout
     assert "8 risk policies" in seed.stdout
     assert "8 strategy tracks" in seed.stdout
+
+
+def test_cli_kill_switch_lifecycle(tmp_path: Path) -> None:
+    db_path = tmp_path / "kill.db"
+    url = f"sqlite:///{db_path.as_posix()}"
+    runner = CliRunner()
+
+    init = runner.invoke(app, ["db", "init", "--database-url", url])
+    assert init.exit_code == 0, init.stdout
+
+    status_off = runner.invoke(app, ["kill", "status", "--database-url", url])
+    assert status_off.exit_code == 0
+    assert "not engaged" in status_off.stdout.lower()
+
+    engage = runner.invoke(
+        app,
+        ["kill", "on", "smoke-test", "--by", "tester", "--database-url", url],
+    )
+    assert engage.exit_code == 0
+    assert "engaged" in engage.stdout.lower()
+
+    status_on = runner.invoke(app, ["kill", "status", "--database-url", url])
+    assert status_on.exit_code == 0
+    assert "engaged" in status_on.stdout.lower()
+    assert "smoke-test" in status_on.stdout
+
+    release = runner.invoke(app, ["kill", "off", "--database-url", url])
+    assert release.exit_code == 0
+    assert "released" in release.stdout.lower()
+
+
+def test_cli_track_pause_resume_lifecycle(tmp_path: Path) -> None:
+    db_path = tmp_path / "pause.db"
+    url = f"sqlite:///{db_path.as_posix()}"
+    runner = CliRunner()
+    assert runner.invoke(
+        app, ["db", "init", "--database-url", url]
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["tracks", "seed", "--database-url", url]
+    ).exit_code == 0
+
+    pause = runner.invoke(
+        app,
+        ["track", "pause", "yolo", "--reason", "audit", "--database-url", url],
+    )
+    assert pause.exit_code == 0
+    assert "paused" in pause.stdout.lower()
+
+    status = runner.invoke(app, ["track", "status", "--database-url", url])
+    assert status.exit_code == 0
+    assert "yolo" in status.stdout.lower()
+
+    resume = runner.invoke(app, ["track", "resume", "yolo", "--database-url", url])
+    assert resume.exit_code == 0
+    assert "resumed" in resume.stdout.lower()
+
+
+def test_cli_run_window_smoke_persists(tmp_path: Path) -> None:
+    db_path = tmp_path / "window.db"
+    url = f"sqlite:///{db_path.as_posix()}"
+    runner = CliRunner()
+    assert runner.invoke(
+        app, ["db", "init", "--database-url", url]
+    ).exit_code == 0
+    assert runner.invoke(
+        app, ["tracks", "seed", "--database-url", url]
+    ).exit_code == 0
+
+    out = runner.invoke(
+        app,
+        [
+            "agents", "run-window",
+            "-t", "balanced",
+            "-s", "AAPL",
+            "--fake",
+            "--window-label", "smoke",
+            "--database-url", url,
+        ],
+    )
+    assert out.exit_code == 0, out.stdout
+    assert "window run" in out.stdout.lower()
+    assert "balanced" in out.stdout.lower()
+

--- a/tests/test_ids.py
+++ b/tests/test_ids.py
@@ -1,0 +1,101 @@
+"""Tests for deterministic ID helpers (Phase 4 replay determinism)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+from stockripper.agents.ids import (
+    action_id,
+    agent_run_id,
+    decision_id,
+    packet_id,
+    recommendation_id,
+    track_run_id,
+    window_run_id,
+)
+
+
+def test_window_run_id_is_deterministic_for_identical_inputs() -> None:
+    when = dt.datetime(2026, 5, 28, 14, 30, 0, tzinfo=dt.UTC)
+    a = window_run_id(
+        window_label="opening",
+        trading_day=when.date(),
+        config_hash="cfg",
+        started_at=when,
+    )
+    b = window_run_id(
+        window_label="opening",
+        trading_day=when.date(),
+        config_hash="cfg",
+        started_at=when,
+    )
+    assert a == b
+    assert a.startswith("win_")
+    assert len(a) == len("win_") + 24
+
+
+def test_window_run_id_differs_when_any_part_differs() -> None:
+    when = dt.datetime(2026, 5, 28, 14, 30, 0, tzinfo=dt.UTC)
+    base = window_run_id(
+        window_label="opening",
+        trading_day=when.date(),
+        config_hash="cfg",
+        started_at=when,
+    )
+    diff_label = window_run_id(
+        window_label="midday",
+        trading_day=when.date(),
+        config_hash="cfg",
+        started_at=when,
+    )
+    diff_day = window_run_id(
+        window_label="opening",
+        trading_day=when.date() + dt.timedelta(days=1),
+        config_hash="cfg",
+        started_at=when,
+    )
+    diff_started = window_run_id(
+        window_label="opening",
+        trading_day=when.date(),
+        config_hash="cfg",
+        started_at=when + dt.timedelta(seconds=1),
+    )
+    diff_cfg = window_run_id(
+        window_label="opening",
+        trading_day=when.date(),
+        config_hash="cfg2",
+        started_at=when,
+    )
+    assert len({base, diff_label, diff_day, diff_started, diff_cfg}) == 5
+
+
+def test_track_packet_agent_rec_decision_action_ids_all_stable() -> None:
+    win = "win_" + "0" * 24
+    trk = track_run_id(window_run_id=win, track_id="balanced", packet_id="pkt_1")
+    pkt = packet_id(track_id="balanced", window_run_id=win, symbol="AAPL")
+    agr = agent_run_id(track_run_id=trk, agent_id="value", input_hash="0" * 64)
+    rec = recommendation_id(agent_run_id=agr, symbol="AAPL")
+    dec = decision_id(track_run_id=trk, judge_agent_id="judge_balanced")
+    act = action_id(decision_id=dec, ordinal=0, symbol="AAPL")
+
+    # All deterministic — re-deriving with same inputs must match.
+    assert trk == track_run_id(
+        window_run_id=win, track_id="balanced", packet_id="pkt_1",
+    )
+    assert pkt == packet_id(
+        track_id="balanced", window_run_id=win, symbol="AAPL",
+    )
+    assert agr == agent_run_id(
+        track_run_id=trk, agent_id="value", input_hash="0" * 64,
+    )
+    assert rec == recommendation_id(agent_run_id=agr, symbol="AAPL")
+    assert dec == decision_id(track_run_id=trk, judge_agent_id="judge_balanced")
+    assert act == action_id(decision_id=dec, ordinal=0, symbol="AAPL")
+
+    # And all have the expected prefix + length.
+    for value, prefix in (
+        (trk, "trk_"), (pkt, "pkt_"), (agr, "agr_"),
+        (rec, "rec_"), (dec, "dec_"), (act, "act_"),
+    ):
+        assert value.startswith(prefix)
+        assert len(value) == len(prefix) + 24

--- a/tests/test_persistence.py
+++ b/tests/test_persistence.py
@@ -1,0 +1,183 @@
+"""Tests for the Phase-4 persistence translator."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.agents.canned_llm import CannedCouncilLLM
+from stockripper.agents.demo import build_demo_packet
+from stockripper.agents.ids import (
+    packet_id as derive_packet_id,
+)
+from stockripper.agents.ids import (
+    track_run_id as derive_track_run_id,
+)
+from stockripper.agents.ids import (
+    window_run_id as derive_window_run_id,
+)
+from stockripper.agents.orchestrator import run_track
+from stockripper.agents.persistence import (
+    persist_failed_track,
+    persist_skipped_track,
+    persist_track_run,
+)
+from stockripper.agents.registry import build_registry
+from stockripper.db import Base, Repository, build_engine
+from stockripper.db.models import AgentRun, JudgeDecision, TrackRun
+from stockripper.tracks import seed_default_tracks
+
+_FROZEN_NOW = dt.datetime(2026, 5, 28, 14, 30, 0, tzinfo=dt.UTC)
+
+
+@pytest.fixture
+def session() -> Session:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    return s
+
+
+async def test_persist_track_run_writes_track_agent_recs_and_decision(
+    session: Session,
+) -> None:
+    registry = build_registry()
+    run_id = derive_window_run_id(
+        window_label="opening", trading_day=_FROZEN_NOW.date(),
+        config_hash="cfg", started_at=_FROZEN_NOW,
+    )
+    pid = derive_packet_id(
+        track_id="balanced", window_run_id=run_id, symbol="AAPL",
+    )
+    packet = build_demo_packet(
+        symbol="AAPL", track_id="balanced", window_id="opening",
+        packet_id=pid, now=_FROZEN_NOW,
+    )
+    llm = CannedCouncilLLM(packet=packet, clock=_FROZEN_NOW)
+    result = await run_track(
+        registry=registry,
+        track_id="balanced",
+        packet=packet,
+        llm=llm,
+        window_id="opening",
+        window_run_id=run_id,
+        now=_FROZEN_NOW,
+    )
+
+    repo = Repository(session)
+    repo.create_run(
+        run_id=run_id, window_label="opening", trading_day=_FROZEN_NOW.date(),
+        config_hash="cfg", started_at=_FROZEN_NOW,
+    )
+    persist_track_run(repo, run_id=run_id, result=result, completed_at=_FROZEN_NOW)
+    session.commit()
+
+    track_runs = session.query(TrackRun).filter(TrackRun.run_id == run_id).all()
+    assert len(track_runs) == 1
+    assert track_runs[0].track_run_id == result.track_run_id
+
+    agent_runs = session.query(AgentRun).filter(AgentRun.run_id == run_id).all()
+    assert len(agent_runs) >= 1
+    # Every persisted agent run carries the deterministic agr_ prefix
+    assert all(ar.agent_run_id.startswith("agr_") for ar in agent_runs)
+
+    decisions = session.query(JudgeDecision).filter(
+        JudgeDecision.run_id == run_id
+    ).all()
+    assert len(decisions) == 1
+
+
+async def test_persist_track_run_is_idempotent(session: Session) -> None:
+    registry = build_registry()
+    run_id = derive_window_run_id(
+        window_label="opening", trading_day=_FROZEN_NOW.date(),
+        config_hash="cfg", started_at=_FROZEN_NOW,
+    )
+    pid = derive_packet_id(
+        track_id="balanced", window_run_id=run_id, symbol="AAPL",
+    )
+    packet = build_demo_packet(
+        symbol="AAPL", track_id="balanced", window_id="opening",
+        packet_id=pid, now=_FROZEN_NOW,
+    )
+    llm = CannedCouncilLLM(packet=packet, clock=_FROZEN_NOW)
+    result = await run_track(
+        registry=registry, track_id="balanced", packet=packet, llm=llm,
+        window_id="opening", window_run_id=run_id, now=_FROZEN_NOW,
+    )
+
+    repo = Repository(session)
+    repo.create_run(
+        run_id=run_id, window_label="opening", trading_day=_FROZEN_NOW.date(),
+        config_hash="cfg", started_at=_FROZEN_NOW,
+    )
+    persist_track_run(repo, run_id=run_id, result=result, completed_at=_FROZEN_NOW)
+    session.commit()
+    persist_track_run(repo, run_id=run_id, result=result, completed_at=_FROZEN_NOW)
+    session.commit()
+
+    track_runs = session.query(TrackRun).filter(TrackRun.run_id == run_id).all()
+    assert len(track_runs) == 1
+    decisions = session.query(JudgeDecision).filter(
+        JudgeDecision.run_id == run_id
+    ).all()
+    assert len(decisions) == 1
+
+
+def test_persist_skipped_track_marker(session: Session) -> None:
+    repo = Repository(session)
+    repo.create_run(
+        run_id="win_skip", window_label="opening",
+        trading_day=_FROZEN_NOW.date(), config_hash="cfg",
+        started_at=_FROZEN_NOW,
+    )
+    persist_skipped_track(
+        repo,
+        run_id="win_skip",
+        track_run_id=derive_track_run_id(
+            window_run_id="win_skip", track_id="balanced", packet_id="pkt_x",
+        ),
+        track_id="balanced",
+        packet_id="pkt_x",
+        symbol="AAPL",
+        started_at=_FROZEN_NOW,
+        reason="paused for test",
+    )
+    session.commit()
+
+    rows = session.query(TrackRun).filter(TrackRun.run_id == "win_skip").all()
+    assert len(rows) == 1
+    assert rows[0].status == "skipped_paused"
+    assert rows[0].interrupt_reason == "paused for test"
+
+
+def test_persist_failed_track_marker(session: Session) -> None:
+    repo = Repository(session)
+    repo.create_run(
+        run_id="win_fail", window_label="opening",
+        trading_day=_FROZEN_NOW.date(), config_hash="cfg",
+        started_at=_FROZEN_NOW,
+    )
+    persist_failed_track(
+        repo,
+        run_id="win_fail",
+        track_run_id=derive_track_run_id(
+            window_run_id="win_fail", track_id="balanced", packet_id="pkt_x",
+        ),
+        track_id="balanced",
+        packet_id="pkt_x",
+        symbol="AAPL",
+        started_at=_FROZEN_NOW,
+        completed_at=_FROZEN_NOW + dt.timedelta(seconds=1),
+        reason="boom",
+    )
+    session.commit()
+    rows = session.query(TrackRun).filter(TrackRun.run_id == "win_fail").all()
+    assert len(rows) == 1
+    assert rows[0].status == "failed"
+    assert rows[0].interrupt_reason == "boom"

--- a/tests/test_repository_phase4.py
+++ b/tests/test_repository_phase4.py
@@ -1,0 +1,133 @@
+"""Tests for the Phase-4 Repository methods (track_runs, agent_runs, control plane)."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.db import Base, Repository, build_engine
+from stockripper.tracks import seed_default_tracks
+
+
+@pytest.fixture
+def session() -> Session:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    return s
+
+
+def _utc(year: int = 2026, month: int = 5, day: int = 28) -> dt.datetime:
+    return dt.datetime(year, month, day, 15, 0, 0, tzinfo=dt.UTC)
+
+
+def test_create_run_is_idempotent(session: Session) -> None:
+    repo = Repository(session)
+    when = _utc()
+    a = repo.create_run(
+        run_id="win_test1", window_label="opening",
+        trading_day=when.date(), config_hash="cfg1", started_at=when,
+    )
+    b = repo.create_run(
+        run_id="win_test1", window_label="opening",
+        trading_day=when.date(), config_hash="cfg1", started_at=when,
+    )
+    assert a is b
+    assert a.status == "running"
+
+
+def test_complete_run_sets_status_and_completed_at(session: Session) -> None:
+    repo = Repository(session)
+    when = _utc()
+    repo.create_run(
+        run_id="win_complete", window_label="opening",
+        trading_day=when.date(), config_hash="cfg", started_at=when,
+    )
+    finished = when + dt.timedelta(seconds=12)
+    run = repo.complete_run(run_id="win_complete", status="ok", completed_at=finished)
+    assert run.status == "ok"
+    assert run.completed_at == finished
+
+
+def test_complete_run_raises_for_unknown_id(session: Session) -> None:
+    repo = Repository(session)
+    with pytest.raises(KeyError):
+        repo.complete_run(run_id="nope", status="ok")
+
+
+def test_upsert_track_run_creates_then_updates(session: Session) -> None:
+    repo = Repository(session)
+    when = _utc()
+    repo.create_run(
+        run_id="win_tr1", window_label="opening",
+        trading_day=when.date(), config_hash="cfg", started_at=when,
+    )
+    created = repo.upsert_track_run(
+        track_run_id="trk_aaaa",
+        run_id="win_tr1",
+        track_id="balanced",
+        packet_id="pkt_x",
+        symbol="AAPL",
+        status="ok",
+        started_at=when,
+    )
+    session.flush()
+    updated = repo.upsert_track_run(
+        track_run_id="trk_aaaa",
+        run_id="win_tr1",
+        track_id="balanced",
+        packet_id="pkt_x",
+        symbol="AAPL",
+        status="partial",
+        started_at=when,
+        completed_at=when + dt.timedelta(seconds=5),
+        interrupt_reason="qa",
+    )
+    assert created is updated
+    assert updated.status == "partial"
+    assert updated.interrupt_reason == "qa"
+
+
+def test_kill_switch_engage_release_cycle(session: Session) -> None:
+    repo = Repository(session)
+    initial = repo.get_kill_switch()
+    assert initial.engaged is False
+    when = _utc()
+    state = repo.engage_kill_switch(
+        reason="rate-limited by exchange", engaged_by="op", when=when,
+    )
+    assert state.engaged is True
+    assert state.reason == "rate-limited by exchange"
+    assert state.engaged_at == when
+    released = repo.release_kill_switch(when=when + dt.timedelta(seconds=30))
+    assert released.engaged is False
+    assert released.reason is None
+
+
+def test_pause_track_then_resume(session: Session) -> None:
+    repo = Repository(session)
+    when = _utc()
+    paused = repo.pause_track(
+        track_id="yolo", reason="risk_review", paused_by="op", when=when,
+    )
+    assert paused.paused is True
+    assert "yolo" in repo.list_paused_track_ids()
+
+    resumed = repo.resume_track(track_id="yolo", when=when + dt.timedelta(minutes=1))
+    assert resumed.paused is False
+    assert repo.list_paused_track_ids() == []
+
+
+def test_list_track_pause_states_returns_history(session: Session) -> None:
+    repo = Repository(session)
+    when = _utc()
+    repo.pause_track(track_id="yolo", reason="r1", when=when)
+    repo.pause_track(track_id="aggressive", reason="r2", when=when)
+    rows = repo.list_track_pause_states()
+    track_ids = {r.track_id for r in rows}
+    assert track_ids == {"yolo", "aggressive"}

--- a/tests/test_window_runner.py
+++ b/tests/test_window_runner.py
@@ -1,0 +1,255 @@
+"""Tests for the Phase-4 Strategy Tracks Manager (window_runner).
+
+Covers:
+* Multi-(track, symbol) fan-out and persistence.
+* Kill-switch pre-flight aborts everything with status=aborted_kill.
+* Per-track pause skips the track but lets siblings run.
+* Failures inside one track do not crash the window.
+* Replay determinism: re-running with the same inputs reproduces identical
+  ``run_id`` / ``track_run_id`` / ``decision_id`` / ``action_id`` values.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.agents.canned_llm import CannedCouncilLLM
+from stockripper.agents.registry import build_registry
+from stockripper.agents.schemas import EvidencePacket
+from stockripper.agents.window_runner import run_window
+from stockripper.db import Base, Repository, build_engine
+from stockripper.db.models import AgentRun, JudgeDecision, Run, TrackRun
+from stockripper.tracks import seed_default_tracks
+
+_FROZEN_NOW = dt.datetime(2026, 5, 28, 14, 30, 0, tzinfo=dt.UTC)
+
+
+@pytest.fixture
+def session_factory() -> sessionmaker[Session]:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    s.close()
+    return factory
+
+
+def _llm_factory(packet: EvidencePacket) -> CannedCouncilLLM:
+    return CannedCouncilLLM(packet=packet, clock=_FROZEN_NOW)
+
+
+async def test_run_window_persists_per_track_audit(
+    session_factory: sessionmaker[Session],
+) -> None:
+    registry = build_registry()
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced", "yolo"),
+        symbols=("AAPL", "MSFT"),
+        window_label="opening",
+        config_hash="cfg-test",
+        rng_seed=42,
+        now=_FROZEN_NOW,
+        llm_factory=_llm_factory,
+        session_factory=session_factory,
+    )
+    assert result.status == "ok"
+    assert len(result.outcomes) == 4
+    assert all(o.status == "ok" for o in result.outcomes)
+
+    with session_factory() as s:
+        repo = Repository(s)
+        run = repo.get_run(result.run_id)
+        assert run is not None
+        assert run.status == "ok"
+        assert run.completed_at is not None
+        track_runs = repo.list_track_runs(run_id=result.run_id)
+        assert len(track_runs) == 4
+        # Each track-run should have produced council + adversarial + judge agent runs.
+        agent_runs = s.query(AgentRun).filter(AgentRun.run_id == result.run_id).all()
+        assert len(agent_runs) >= 4  # at least one judge per track-run
+        decisions = s.query(JudgeDecision).filter(
+            JudgeDecision.run_id == result.run_id
+        ).all()
+        assert len(decisions) == 4
+
+
+async def test_run_window_kill_switch_aborts_everything(
+    session_factory: sessionmaker[Session],
+) -> None:
+    registry = build_registry()
+    with session_factory() as s:
+        repo = Repository(s)
+        repo.engage_kill_switch(reason="ops_drill", engaged_by="test", when=_FROZEN_NOW)
+        s.commit()
+
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced", "yolo"),
+        symbols=("AAPL",),
+        window_label="opening",
+        config_hash="cfg-kill",
+        now=_FROZEN_NOW,
+        llm_factory=_llm_factory,
+        session_factory=session_factory,
+    )
+    assert result.status == "aborted_kill"
+    assert all(o.status == "aborted_kill" for o in result.outcomes)
+
+    with session_factory() as s:
+        run = s.query(Run).filter(Run.run_id == result.run_id).one()
+        assert run.status == "aborted_kill"
+        track_runs = s.query(TrackRun).filter(TrackRun.run_id == result.run_id).all()
+        assert len(track_runs) == 2
+        for tr in track_runs:
+            assert tr.status == "aborted_kill"
+            assert tr.interrupt_reason is not None
+            assert "kill" in tr.interrupt_reason
+
+
+async def test_run_window_pause_skips_only_paused_track(
+    session_factory: sessionmaker[Session],
+) -> None:
+    registry = build_registry()
+    with session_factory() as s:
+        repo = Repository(s)
+        repo.pause_track(track_id="yolo", reason="manual", when=_FROZEN_NOW)
+        s.commit()
+
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced", "yolo"),
+        symbols=("AAPL",),
+        window_label="opening",
+        config_hash="cfg-pause",
+        now=_FROZEN_NOW,
+        llm_factory=_llm_factory,
+        session_factory=session_factory,
+    )
+    assert result.status == "ok"
+    skipped = [o for o in result.outcomes if o.status == "skipped_paused"]
+    okays = [o for o in result.outcomes if o.status == "ok"]
+    assert len(skipped) == 1 and skipped[0].track_id == "yolo"
+    assert len(okays) == 1 and okays[0].track_id == "balanced"
+
+    with session_factory() as s:
+        track_runs = s.query(TrackRun).filter(TrackRun.run_id == result.run_id).all()
+        assert len(track_runs) == 2
+        statuses = {tr.track_id: tr.status for tr in track_runs}
+        assert statuses["yolo"] == "skipped_paused"
+        assert statuses["balanced"] == "ok"
+
+
+async def test_run_window_isolates_one_track_failure(
+    session_factory: sessionmaker[Session],
+) -> None:
+    registry = build_registry()
+    healthy_packet_factory = _llm_factory
+
+    def _selective_factory(packet: EvidencePacket) -> CannedCouncilLLM | None:
+        # For "yolo" we hand back a stub LLM that raises on every call.
+        # ``BaseAgent.run`` converts the RuntimeError into a quarantined
+        # AgentRunResult, so the yolo track-run lands as ``partial``
+        # instead of crashing the window.
+        if packet.track_id == "yolo":
+            class _Boom:
+                def bind_packet(self, *_a: object, **_kw: object) -> None: ...
+                def bind_clock(self, *_a: object, **_kw: object) -> None: ...
+                def run_structured(
+                    self, *_a: object, **_kw: object,
+                ) -> object:
+                    raise RuntimeError("synthetic LLM failure for yolo")
+            return _Boom()  # type: ignore[return-value]
+        return healthy_packet_factory(packet)
+
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced", "yolo"),
+        symbols=("AAPL",),
+        window_label="opening",
+        config_hash="cfg-iso",
+        now=_FROZEN_NOW,
+        llm_factory=_selective_factory,
+        session_factory=session_factory,
+    )
+    # The window status should be "partial" because yolo quarantines its
+    # agents (quarantine -> track status "partial", not "failed").
+    assert result.status == "partial"
+    outcomes_by_track = {o.track_id: o for o in result.outcomes}
+    assert outcomes_by_track["balanced"].status == "ok"
+    assert outcomes_by_track["yolo"].status == "partial"
+
+
+async def test_replay_reproduces_identical_ids(
+    session_factory: sessionmaker[Session],
+) -> None:
+    """Two runs with identical inputs must produce identical persisted ids."""
+
+    registry = build_registry()
+
+    async def _drive(label: str) -> tuple[str, set[str], set[str], set[str]]:
+        result = await run_window(
+            registry=registry,
+            track_ids=("balanced",),
+            symbols=("AAPL", "MSFT"),
+            window_label=label,
+            config_hash="cfg-replay",
+            rng_seed=7,
+            now=_FROZEN_NOW,
+            llm_factory=_llm_factory,
+            session_factory=session_factory,
+        )
+        track_runs = {o.track_run_id for o in result.outcomes}
+        decision_ids = {
+            o.result.judge_decision.plan.decision_id
+            for o in result.outcomes
+            if o.result is not None and o.result.judge_decision is not None
+        }
+        action_ids = {
+            item.action_id
+            for o in result.outcomes
+            if o.result is not None and o.result.judge_decision is not None
+            for item in o.result.judge_decision.plan.items
+        }
+        return result.run_id, track_runs, decision_ids, action_ids
+
+    run_id_a, trks_a, decs_a, acts_a = await _drive("replay-window")
+    run_id_b, trks_b, decs_b, acts_b = await _drive("replay-window")
+
+    assert run_id_a == run_id_b, "window run_id must be deterministic"
+    assert trks_a == trks_b, "track_run_ids must be deterministic"
+    assert decs_a == decs_b, "decision_ids must be deterministic"
+    assert acts_a == acts_b, "action_ids must be deterministic"
+
+    # And the persisted rows should have been upserted (no duplicates).
+    with session_factory() as s:
+        runs = s.query(Run).filter(Run.run_id == run_id_a).all()
+        assert len(runs) == 1
+        track_runs = s.query(TrackRun).filter(TrackRun.run_id == run_id_a).all()
+        assert {tr.track_run_id for tr in track_runs} == trks_a
+
+
+async def test_run_window_no_persist_skips_db(
+    session_factory: sessionmaker[Session],
+) -> None:
+    registry = build_registry()
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced",),
+        symbols=("AAPL",),
+        window_label="adhoc",
+        config_hash="cfg-nopersist",
+        now=_FROZEN_NOW,
+        llm_factory=_llm_factory,
+        persist=False,
+    )
+    assert result.status == "ok"
+    assert len(result.outcomes) == 1
+    # No rows should exist in our fixture DB.
+    with session_factory() as s:
+        assert s.query(Run).filter(Run.run_id == result.run_id).one_or_none() is None


### PR DESCRIPTION
Phase 4 full implementation: Strategy Tracks Manager with parallel multi-track execution, replay-deterministic IDs, kill-switch + per-track pause control plane, and a complete persistence layer for the agent graph.

Spec acceptance (section 25 Phase 4): End-to-end workflow runs all enabled tracks in parallel with mocked execution; replay reproduces decisions. Verified by test_replay_reproduces_identical_ids.

What is new:

- agents/ids.py — SHA256-derived IDs for window/track/agent/recommendation/decision/action/packet so re-running a window yields identical persisted rows.
- agents/window_runner.py — Strategy Tracks Manager. Runs (track x symbol) in parallel via asyncio.gather(return_exceptions=True), honors kill-switch + per-track pause, persists each track in its own session_scope so one track failure does not roll back peers.
- agents/persistence.py — pure translator from TrackRunResult to TrackRun / AgentRun / Recommendation / JudgeDecision / DecisionAction rows.
- agents/canned_llm.py — stateless. packet + clock at ctor; all synthesized outputs deterministic via _stable_id_seed.
- agents/orchestrator.py — threads window_run_id + frozen now, derives deterministic ids, defensively re-binds packet/clock on legacy LLM clients.
- Alembic — initial Phase-1 migration scoped to an explicit allow-list so the new 20260528_phase4_orchestrator revision can create track_runs / agent_runs / kill_switch_state / track_pause_state via op.create_table without colliding.
- db/repository.py — 12 new write methods, all flush so within-session upsert idempotency works under autoflush=False sessions.
- CLI — stockripper kill on|off|status, stockripper track pause|resume|status, stockripper agents run-window --track ... --symbol ... [--fake] [--persist].

Tests: 23 new (ids, repository Phase-4, persistence translator, window runner kill/pause/failure-isolation/no-persist/replay, CLI lifecycle). Suite 205/205 green, ruff clean, mypy strict clean.

Deferred to a follow-up PR (not blocking acceptance): a true langgraph.StateGraph wrapper with MemorySaver checkpointing and node-level event hooks. Today's run_track is functionally equivalent (parallel fan-out, deterministic state, replay) but lacks the explicit graph topology object.
