### PR TITLE
Phase 5: per-track risk gates + paper execution adapter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -159,69 +159,13 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-# .NET build directories
-bin/
-obj/
-
-# Rider, Visual Studio, and VSCode settings
+# IDE / editor settings
 .idea/
 .vscode/
-*.suo
-*.user
-*.userosscache
-*.sln.docstates
-
-# Mono Auto Generated Files
-mono_crash.*
-
-# Visual Studio for Mac
-.vscode/settings.json
-.vscode/tasks.json
-.vscode/launch.json
-.vscode/*.cache
-.vscode/**/*.cache
-.vscode/*.log
-.vscode/*.tlog
-.vscode/*.idx
-.vscode/.DS_Store
-.vscode/*.pidb
-
-# Package directories
-**/packages/
-**/node_modules/
-
-# Paket dependencies
-.paket/
-paket-files/
-
-# Dotnet tools
-.tool_versions
-.dotnet_tool.json
-
-# Build artifacts
-*.dll
-*.exe
-*.app
-*.dylib
-*.so
-*.pdb
-*.nuspec
-*.nupkg
-
-# Publish artifacts
-.publish/
 
 # Logs
 *.log
-*.trace
 *.swp
-
-# Cache directories
-.nuget/
-.npm/
-
-# VSCode Debug Files
-.vscode/
 
 # OS generated files
 .DS_Store
@@ -231,9 +175,7 @@ Thumbs.db
 *.tmp
 *.bak
 *.old
-*.swp
 *.swo
-*.err
 
 .env
 parameters.json

--- a/src/stockripper/__main__.py
+++ b/src/stockripper/__main__.py
@@ -1031,6 +1031,22 @@ def agents_run_window(
         True, "--persist/--no-persist",
         help="When --persist, write run/track/agent rows to the DB (default).",
     ),
+    execute: bool = typer.Option(
+        False, "--execute/--no-execute",
+        help=(
+            "When --execute, submit approved actions through the execution "
+            "adapter (defaults to the mock broker; pass --alpaca for paper "
+            "submission). Requires --persist."
+        ),
+    ),
+    alpaca: bool = typer.Option(
+        False, "--alpaca/--mock",
+        help=(
+            "Broker selector for --execute. --alpaca submits paper orders "
+            "via alpaca-py; --mock (default) uses the in-process mock that "
+            "synthesizes immediate fills."
+        ),
+    ),
     seed: int | None = typer.Option(
         None, "--seed", help="rng_seed propagated to every agent run.",
     ),
@@ -1039,7 +1055,9 @@ def agents_run_window(
     """Run every (track, symbol) pair in parallel via the Strategy Tracks Manager.
 
     Honors the global kill-switch and per-track pause state. Without
-    ``--persist`` no DB writes happen — useful for offline demos.
+    ``--persist`` no DB writes happen — useful for offline demos. With
+    ``--execute`` the per-track risk gate runs and approved orders are
+    submitted through the chosen broker (mock by default).
     """
 
     from sqlalchemy.orm import sessionmaker
@@ -1055,10 +1073,45 @@ def agents_run_window(
     )
     symbols = tuple(s.upper() for s in symbol)
 
-    factory = None
+    factory: Any = None
     if persist:
         engine = build_engine(database_url)
         factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+
+    if execute and not persist:
+        console.print(
+            "[bold red]--execute requires --persist (no audit row, no submit).[/]"
+        )
+        raise typer.Exit(code=2)
+
+    execution_adapter: Any = None
+    if execute:
+        from stockripper.execution.adapter import (
+            AlpacaPaperBrokerClient,
+            ExecutionAdapter,
+            MockBrokerClient,
+        )
+
+        broker: Any
+        settings: StockripperSettings | None
+        if alpaca:
+            settings = load_settings()
+            settings.assert_paper_only()
+            broker = AlpacaPaperBrokerClient(settings)
+            console.print(
+                f"[bold yellow]execute mode: alpaca paper broker "
+                f"(endpoint={settings.alpaca_base_url})[/]"
+            )
+        else:
+            settings = None
+            broker = MockBrokerClient()
+            console.print("[yellow]execute mode: mock broker (synthetic fills)[/]")
+        execution_adapter = ExecutionAdapter(
+            session_factory=factory,
+            broker=broker,
+            window_id=window_label,
+            settings=settings,
+        )
 
     if fake:
         console.print("[yellow]offline mode: using CannedCouncilLLM per coroutine[/yellow]")
@@ -1089,6 +1142,7 @@ def agents_run_window(
             persist=persist,
             session_factory=factory,
             llm_factory=llm_factory,
+            execution_adapter=execution_adapter,
         )
         _print_window_result(result)
 
@@ -1128,5 +1182,30 @@ def _print_window_result(result: Any) -> None:
         }.get(o.status, o.status)
         table.add_row(o.track_id, o.symbol, status_text, items, note)
     console.print(table)
+
+    submissions = getattr(result, "submissions", ()) or ()
+    if submissions:
+        sub_table = Table(title=f"Execution submissions ({len(submissions)})")
+        sub_table.add_column("track_id", style="bold cyan")
+        sub_table.add_column("symbol")
+        sub_table.add_column("status", justify="center")
+        sub_table.add_column("client_order_id", overflow="fold")
+        sub_table.add_column("reason", overflow="fold")
+        sub_status_style = {
+            "submitted": "[green]submitted[/]",
+            "duplicate": "[blue]duplicate[/]",
+            "rejected_floor": "[bold red]floor[/]",
+            "rejected_risk": "[red]risk[/]",
+            "error": "[bold red]error[/]",
+        }
+        for s in submissions:
+            sub_table.add_row(
+                s.track_id,
+                s.symbol,
+                sub_status_style.get(s.status.value, s.status.value),
+                s.client_order_id or "-",
+                (s.reason or "")[:90],
+            )
+        console.print(sub_table)
 
 

--- a/src/stockripper/agents/window_runner.py
+++ b/src/stockripper/agents/window_runner.py
@@ -44,6 +44,11 @@ from stockripper.agents.registry import AgentRegistry
 from stockripper.agents.schemas import EvidencePacket
 from stockripper.db.engine import build_session_factory, session_scope
 from stockripper.db.repository import Repository
+from stockripper.execution.adapter import (
+    ExecutionAdapter,
+    SubmissionResult,
+    SubmissionStatus,
+)
 
 LOG: Final = logging.getLogger(__name__)
 
@@ -82,6 +87,7 @@ class WindowRunResult:
     status: str
     """One of: ok, partial, aborted_kill, failed."""
     outcomes: tuple[TrackOutcome, ...] = field(default_factory=tuple)
+    submissions: tuple[SubmissionResult, ...] = field(default_factory=tuple)
 
     @property
     def ok_outcomes(self) -> tuple[TrackOutcome, ...]:
@@ -117,6 +123,7 @@ async def run_window(
     persist: bool = True,
     session_factory: sessionmaker[Session] | None = None,
     packet_builder: PacketBuilder | None = None,
+    execution_adapter: ExecutionAdapter | None = None,
 ) -> WindowRunResult:
     """Run every enabled (track, symbol) pair in parallel.
 
@@ -341,6 +348,17 @@ async def run_window(
             else None,
         )
 
+    submissions: tuple[SubmissionResult, ...] = ()
+    if (
+        persist
+        and execution_adapter is not None
+        and final_status != "aborted_kill"
+    ):
+        submissions = _execute_actions(
+            outcomes=all_outcomes,
+            adapter=execution_adapter,
+        )
+
     return WindowRunResult(
         run_id=run_id,
         window_label=window_label,
@@ -349,6 +367,7 @@ async def run_window(
         completed_at=completed_at,
         status=final_status,
         outcomes=all_outcomes,
+        submissions=submissions,
     )
 
 
@@ -548,6 +567,47 @@ def _finalize_run(
                 run.notes = notes
     except Exception:
         LOG.exception("Failed to finalize run %s", run_id)
+
+
+def _execute_actions(
+    *,
+    outcomes: tuple[TrackOutcome, ...],
+    adapter: ExecutionAdapter,
+) -> tuple[SubmissionResult, ...]:
+    """Submit every OK/partial outcome's judge-decision items through the adapter.
+
+    The adapter handles its own kill-switch / pause re-check via the
+    universal-floor stack so a kill or pause that lands between
+    persistence and submission still blocks the order.
+    """
+
+    results: list[SubmissionResult] = []
+    for o in outcomes:
+        if o.status not in {"ok", "partial"}:
+            continue
+        if o.result is None or o.result.judge_decision is None:
+            continue
+        for item in o.result.judge_decision.plan.items:
+            try:
+                results.append(adapter.submit_action(item))
+            except Exception as exc:  # log + continue, never crash window
+                LOG.exception(
+                    "Execution adapter raised for action %s/%s",
+                    o.track_id, item.action_id,
+                )
+                results.append(
+                    SubmissionResult(
+                        action_id=item.action_id,
+                        track_id=o.track_id,
+                        symbol=item.symbol,
+                        status=SubmissionStatus.REJECTED_FLOOR,
+                        client_order_id=None,
+                        local_order_id=None,
+                        reason=f"adapter_exception:{exc!r}",
+                        risk_status_label="rejected_floor:adapter_exception",
+                    )
+                )
+    return tuple(results)
 
 
 __all__ = (

--- a/src/stockripper/db/repository.py
+++ b/src/stockripper/db/repository.py
@@ -188,6 +188,92 @@ class Repository:
         return fill
 
     # ------------------------------------------------------------------
+    # Phase 5 — execution adapter primitives
+    # ------------------------------------------------------------------
+    def find_order_by_client_order_id(self, client_order_id: str) -> Order | None:
+        """Look up an order by its deterministic ``client_order_id``."""
+
+        return self.session.execute(
+            select(Order).where(Order.client_order_id == client_order_id)
+        ).scalar_one_or_none()
+
+    def upsert_order(
+        self,
+        *,
+        local_order_id: str,
+        track_id: str,
+        action_id: str | None,
+        client_order_id: str,
+        symbol: str,
+        side: str,
+        order_type: str,
+        time_in_force: str,
+        status: str,
+        requested_notional_usd: Decimal | None = None,
+        requested_qty: Decimal | None = None,
+        limit_price: Decimal | None = None,
+        stop_price: Decimal | None = None,
+        alpaca_order_id: str | None = None,
+        submitted_at: dt.datetime | None = None,
+        raw_request_uri: str | None = None,
+        raw_response_uri: str | None = None,
+    ) -> Order:
+        """Insert or update an ``orders`` row keyed by ``client_order_id``.
+
+        Use this from the execution adapter so the second submission of an
+        identical intent collapses onto the first row (idempotency).
+        """
+
+        existing = self.find_order_by_client_order_id(client_order_id)
+        defaults: dict[str, Any] = {
+            "action_id": action_id,
+            "track_id": track_id,
+            "alpaca_order_id": alpaca_order_id,
+            "client_order_id": client_order_id,
+            "symbol": symbol.upper(),
+            "side": side,
+            "order_type": order_type,
+            "time_in_force": time_in_force,
+            "requested_notional_usd": requested_notional_usd,
+            "requested_qty": requested_qty,
+            "limit_price": limit_price,
+            "stop_price": stop_price,
+            "status": status,
+            "submitted_at": submitted_at,
+            "raw_request_uri": raw_request_uri,
+            "raw_response_uri": raw_response_uri,
+        }
+        if existing is None:
+            order = Order(local_order_id=local_order_id, **defaults)
+            self.session.add(order)
+            self.session.flush()
+            return order
+        for key, value in defaults.items():
+            setattr(existing, key, value)
+        self.session.flush()
+        return existing
+
+    def list_orders_for_track(self, *, track_id: str) -> list[Order]:
+        stmt = (
+            select(Order)
+            .where(Order.track_id == track_id)
+            .order_by(Order.submitted_at.desc().nullslast())
+        )
+        return list(self.session.execute(stmt).scalars())
+
+    def set_action_risk_status(
+        self, *, action_id: str, risk_status: str,
+    ) -> DecisionAction | None:
+        """Set ``decision_actions.risk_status`` for a single action."""
+
+        existing = self.session.get(DecisionAction, action_id)
+        if existing is None:
+            return None
+        existing.risk_status = risk_status
+        self.session.flush()
+        return existing
+
+    # ------------------------------------------------------------------
     # Track snapshots (reconciliation output)
     # ------------------------------------------------------------------
     def record_track_snapshot(

--- a/src/stockripper/execution/adapter.py
+++ b/src/stockripper/execution/adapter.py
@@ -1,0 +1,565 @@
+"""Phase-5 execution adapter (spec §16.1, §25 Phase 5).
+
+The adapter is the **only** code path that may submit orders. The agent
+graph never calls Alpaca directly — it produces :class:`ActionItem` rows;
+the adapter is responsible for:
+
+1. Re-checking the global kill switch + per-track pause (mid-window state
+   can change after :func:`run_window` already started).
+2. Running universal floors (:mod:`stockripper.risk.floors`).
+3. Running the per-track risk gate (:mod:`stockripper.risk.gate`).
+4. Computing the deterministic ``client_order_id`` from the canonical
+   :class:`OrderIntent` so retries collapse to the same order.
+5. Submitting via the underlying client (mock or Alpaca paper).
+6. Persisting the ``orders`` row (and synthesizing a ``fills`` row in mock
+   mode for fast end-to-end demos).
+
+The submission contract is a small :class:`SubmissionResult` value object
+so callers can render and persist outcomes without depending on Alpaca's
+client surface.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any, Final, Protocol
+
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import Session
+
+from stockripper.agents.schemas import ActionItem, ActionOrderType, OrderSide
+from stockripper.config import StockripperSettings
+from stockripper.db.engine import session_scope
+from stockripper.db.models import DecisionAction, StrategyTrack
+from stockripper.db.repository import Repository
+from stockripper.execution.client_order_id import (
+    OrderIntent,
+    build_client_order_id,
+    build_intent_hash,
+)
+from stockripper.risk import DEFAULT_RISK_POLICIES, RiskPolicyParams
+from stockripper.risk.floors import (
+    FloorContext,
+    FloorViolation,
+    check_floors,
+)
+from stockripper.risk.gate import RiskDecision, RiskGate
+from stockripper.risk.portfolio import (
+    PortfolioState,
+    latest_state_from_snapshot,
+)
+
+LOG: Final = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- #
+# Result types
+# --------------------------------------------------------------------------- #
+class SubmissionStatus(StrEnum):
+    """Outcome of a single :meth:`ExecutionAdapter.submit_action` call."""
+
+    SUBMITTED = "submitted"
+    """Order was newly submitted to the underlying broker."""
+
+    DUPLICATE = "duplicate"
+    """An order with the same ``client_order_id`` already existed (idempotent)."""
+
+    REJECTED_FLOOR = "rejected_floor"
+    """A universal floor blocked the submission."""
+
+    REJECTED_RISK = "rejected_risk"
+    """The per-track risk gate rejected the action."""
+
+
+@dataclass(frozen=True)
+class SubmissionResult:
+    """What happened to one :class:`ActionItem`."""
+
+    action_id: str
+    track_id: str
+    symbol: str
+    status: SubmissionStatus
+    client_order_id: str | None
+    local_order_id: str | None
+    reason: str | None = None
+    risk_decision: RiskDecision | None = None
+    risk_status_label: str = ""
+
+
+# --------------------------------------------------------------------------- #
+# Broker client protocol + mock + Alpaca implementations
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class BrokerOrder:
+    """Broker-side representation of a submitted order.
+
+    Adapters return this from :meth:`BrokerClient.submit`. The execution
+    adapter then persists it via :meth:`Repository.upsert_order`.
+    """
+
+    broker_order_id: str
+    client_order_id: str
+    status: str
+    """Broker-reported status (e.g. ``new``, ``accepted``, ``filled``)."""
+
+    submitted_at: dt.datetime
+    filled_qty: Decimal | None = None
+    filled_avg_price: Decimal | None = None
+    filled_at: dt.datetime | None = None
+
+
+class BrokerClient(Protocol):
+    """Minimum surface the execution adapter needs from a broker client."""
+
+    def submit(
+        self,
+        *,
+        intent: OrderIntent,
+        client_order_id: str,
+        track_id: str,
+        window_id: str,
+    ) -> BrokerOrder: ...
+
+
+# --------------------------------------------------------------------------- #
+# Mock broker (default for tests + offline demos)
+# --------------------------------------------------------------------------- #
+@dataclass
+class MockBrokerClient:
+    """Always-fill mock broker.
+
+    Synthesizes a ``filled`` :class:`BrokerOrder` immediately at either the
+    intent's ``limit_price`` (when set) or a stable per-symbol pseudo price
+    derived from a SHA-256 of the symbol. Useful for the Phase 5 acceptance
+    smoke test where we want to see paper orders appear in the ledger
+    without a live network call.
+    """
+
+    now: dt.datetime | None = None
+
+    def submit(
+        self,
+        *,
+        intent: OrderIntent,
+        client_order_id: str,
+        track_id: str,
+        window_id: str,
+    ) -> BrokerOrder:
+        submitted_at = self.now if self.now is not None else _utcnow()
+        price = intent.limit_price or _stable_mock_price(intent.symbol)
+        qty: Decimal
+        if intent.qty is not None:
+            qty = intent.qty
+        elif intent.notional is not None and price > 0:
+            qty = (intent.notional / price).quantize(Decimal("0.000001"))
+        else:
+            qty = Decimal("0")
+        return BrokerOrder(
+            broker_order_id=f"mock_{hashlib.sha256(client_order_id.encode()).hexdigest()[:16]}",
+            client_order_id=client_order_id,
+            status="filled",
+            submitted_at=submitted_at,
+            filled_qty=qty,
+            filled_avg_price=price,
+            filled_at=submitted_at,
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Alpaca paper broker (production)
+# --------------------------------------------------------------------------- #
+class AlpacaPaperBrokerClient:
+    """Adapter around ``alpaca.trading.client.TradingClient`` for paper trading.
+
+    Construction asserts the paper endpoint via
+    :meth:`StockripperSettings.assert_paper_only`. We deliberately do
+    **not** export a factory that allows a non-paper URL — the MVP refuses
+    to construct an execution-capable client against live endpoints
+    (spec §16.1 universal floor #1, §16.1 #8 no real-money path).
+    """
+
+    def __init__(self, settings: StockripperSettings) -> None:
+        settings.assert_paper_only()
+        from alpaca.trading.client import TradingClient
+
+        self._client = TradingClient(
+            api_key=settings.alpaca_api_key_id.get_secret_value(),
+            secret_key=settings.alpaca_api_secret_key.get_secret_value(),
+            paper=True,
+        )
+
+    def submit(
+        self,
+        *,
+        intent: OrderIntent,
+        client_order_id: str,
+        track_id: str,
+        window_id: str,
+    ) -> BrokerOrder:
+        # Build alpaca-py request type lazily so unit tests don't need
+        # alpaca-py installed unless they exercise this path.
+        from alpaca.trading.enums import OrderSide as AlpacaSide
+        from alpaca.trading.enums import TimeInForce as AlpacaTif
+        from alpaca.trading.requests import (
+            LimitOrderRequest,
+            MarketOrderRequest,
+        )
+
+        side_map = {
+            "buy": AlpacaSide.BUY,
+            "sell": AlpacaSide.SELL,
+            "sell_short": AlpacaSide.SELL,
+            "buy_to_cover": AlpacaSide.BUY,
+        }
+        tif_map = {
+            "day": AlpacaTif.DAY,
+            "gtc": AlpacaTif.GTC,
+            "ioc": AlpacaTif.IOC,
+            "fok": AlpacaTif.FOK,
+        }
+        common: dict[str, Any] = {
+            "symbol": intent.symbol,
+            "side": side_map[intent.side],
+            "time_in_force": tif_map[intent.time_in_force],
+            "client_order_id": client_order_id,
+        }
+        if intent.qty is not None:
+            common["qty"] = float(intent.qty)
+        elif intent.notional is not None:
+            common["notional"] = float(intent.notional)
+
+        request: LimitOrderRequest | MarketOrderRequest
+        if intent.order_type == "limit" and intent.limit_price is not None:
+            request = LimitOrderRequest(limit_price=float(intent.limit_price), **common)
+        else:
+            request = MarketOrderRequest(**common)
+
+        response: Any = self._client.submit_order(order_data=request)
+        # alpaca-py returns a model object; map to BrokerOrder.
+        return BrokerOrder(
+            broker_order_id=str(response.id),
+            client_order_id=str(response.client_order_id),
+            status=str(response.status),
+            submitted_at=_coerce_dt(response.submitted_at),
+            filled_qty=_coerce_decimal(getattr(response, "filled_qty", None)),
+            filled_avg_price=_coerce_decimal(getattr(response, "filled_avg_price", None)),
+            filled_at=_coerce_dt(getattr(response, "filled_at", None)),
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Execution adapter
+# --------------------------------------------------------------------------- #
+@dataclass
+class ExecutionAdapter:
+    """Submits action items through the floors + risk-gate stack.
+
+    Construction parameters:
+
+    - ``session_factory``: sessionmaker used to open one short-lived
+      session per :meth:`submit_action` call (control-plane re-check,
+      idempotency lookup, order persistence, fill recording).
+    - ``broker``: the :class:`BrokerClient` to forward approved orders to.
+    - ``window_id``: window identifier passed into the
+      :func:`build_client_order_id` derivation so the same intent inside
+      a different window yields a different id.
+    - ``settings``: :class:`StockripperSettings` (used by floors to
+      re-assert the paper-endpoint invariant).
+    - ``risk_policies``: optional override; defaults to
+      :data:`stockripper.risk.DEFAULT_RISK_POLICIES`.
+    - ``portfolio_provider``: optional callable yielding a
+      :class:`PortfolioState`; defaults to a per-track snapshot lookup.
+    """
+
+    session_factory: sessionmaker[Session]
+    broker: BrokerClient
+    window_id: str
+    settings: StockripperSettings | None = None
+    risk_policies: dict[str, RiskPolicyParams] = field(
+        default_factory=lambda: dict(DEFAULT_RISK_POLICIES),
+    )
+    now: dt.datetime | None = None
+
+    def submit_action(self, action: ActionItem) -> SubmissionResult:
+        intent = _action_to_intent(action)
+        intent_hash = build_intent_hash(intent)
+        client_order_id = build_client_order_id(
+            track_id=action.track_id,
+            intent_hash=intent_hash,
+            window_id=self.window_id,
+        )
+
+        with session_scope(self.session_factory) as session:
+            repo = Repository(session)
+
+            track = repo.get_strategy_track(action.track_id)
+            if track is None:
+                # No track row → we cannot resolve policy or portfolio.
+                # Treat as floor violation so this becomes audit-visible.
+                _persist_action_status(
+                    repo, action.action_id,
+                    f"rejected_floor:unknown_track:{action.track_id}",
+                )
+                return SubmissionResult(
+                    action_id=action.action_id,
+                    track_id=action.track_id,
+                    symbol=action.symbol,
+                    status=SubmissionStatus.REJECTED_FLOOR,
+                    client_order_id=None,
+                    local_order_id=None,
+                    reason=f"unknown_track:{action.track_id}",
+                    risk_status_label=f"rejected_floor:unknown_track:{action.track_id}",
+                )
+
+            kill_state = repo.get_kill_switch()
+            pause = repo.get_track_pause(action.track_id)
+            # By contract, ``submit_action`` is invoked downstream of
+            # ``persist_track_run`` (the audit row for this action was
+            # already written). The audit-completeness floor is here so
+            # an alternative caller cannot accidentally bypass it; when
+            # called via :func:`run_window` the action's ``decision_actions``
+            # row exists by construction.
+            audit_row = repo.session.get(DecisionAction, action.action_id)
+            ctx = FloorContext(
+                kill_switch_engaged=kill_state.engaged,
+                kill_reason=kill_state.reason,
+                track_paused=bool(pause and pause.paused),
+                pause_reason=(pause.reason if pause else None),
+                client_order_id=client_order_id,
+                has_audit_row=audit_row is not None,
+            )
+
+            try:
+                check_floors(action=action, context=ctx, settings=self.settings)
+            except FloorViolation as violation:
+                label = f"rejected_floor:{violation.code.value}"
+                _persist_action_status(repo, action.action_id, label)
+                return SubmissionResult(
+                    action_id=action.action_id,
+                    track_id=action.track_id,
+                    symbol=action.symbol,
+                    status=SubmissionStatus.REJECTED_FLOOR,
+                    client_order_id=client_order_id,
+                    local_order_id=None,
+                    reason=violation.message,
+                    risk_status_label=label,
+                )
+
+            policy = self.risk_policies.get(track.risk_policy_id)
+            if policy is None:
+                label = f"rejected_floor:missing_policy:{track.risk_policy_id}"
+                _persist_action_status(repo, action.action_id, label)
+                return SubmissionResult(
+                    action_id=action.action_id,
+                    track_id=action.track_id,
+                    symbol=action.symbol,
+                    status=SubmissionStatus.REJECTED_FLOOR,
+                    client_order_id=client_order_id,
+                    local_order_id=None,
+                    reason=f"missing risk policy {track.risk_policy_id!r}",
+                    risk_status_label=label,
+                )
+
+            portfolio = self._build_portfolio_state(session, track)
+            gate = RiskGate(policy=policy)
+            decision = gate.evaluate(action=action, portfolio=portfolio)
+            if decision.is_rejected:
+                label = f"rejected_risk:{decision.summary().split(':', 1)[1]}"
+                _persist_action_status(repo, action.action_id, label)
+                return SubmissionResult(
+                    action_id=action.action_id,
+                    track_id=action.track_id,
+                    symbol=action.symbol,
+                    status=SubmissionStatus.REJECTED_RISK,
+                    client_order_id=client_order_id,
+                    local_order_id=None,
+                    reason="; ".join(r.message for r in decision.rejections),
+                    risk_decision=decision,
+                    risk_status_label=label,
+                )
+
+            # Idempotency: if an order with this client_order_id already
+            # exists we don't re-submit; we re-render the existing row.
+            existing = repo.find_order_by_client_order_id(client_order_id)
+            if existing is not None:
+                _persist_action_status(repo, action.action_id, "approved")
+                return SubmissionResult(
+                    action_id=action.action_id,
+                    track_id=action.track_id,
+                    symbol=action.symbol,
+                    status=SubmissionStatus.DUPLICATE,
+                    client_order_id=client_order_id,
+                    local_order_id=existing.local_order_id,
+                    reason="client_order_id already submitted",
+                    risk_decision=decision,
+                    risk_status_label="approved",
+                )
+
+            broker_order = self.broker.submit(
+                intent=intent,
+                client_order_id=client_order_id,
+                track_id=action.track_id,
+                window_id=self.window_id,
+            )
+
+            order = repo.upsert_order(
+                local_order_id=client_order_id,
+                track_id=action.track_id,
+                action_id=action.action_id,
+                client_order_id=client_order_id,
+                symbol=action.symbol,
+                side=intent.side,
+                order_type=intent.order_type,
+                time_in_force=intent.time_in_force,
+                status=broker_order.status,
+                requested_notional_usd=intent.notional,
+                requested_qty=intent.qty,
+                limit_price=intent.limit_price,
+                stop_price=intent.stop_price,
+                alpaca_order_id=broker_order.broker_order_id,
+                submitted_at=broker_order.submitted_at,
+            )
+
+            if (
+                broker_order.filled_qty is not None
+                and broker_order.filled_avg_price is not None
+                and broker_order.filled_at is not None
+            ):
+                repo.record_fill(
+                    fill_id=f"fill_{client_order_id}",
+                    local_order_id=order.local_order_id,
+                    filled_qty=broker_order.filled_qty,
+                    filled_avg_price=broker_order.filled_avg_price,
+                    filled_at=broker_order.filled_at,
+                )
+
+            _persist_action_status(repo, action.action_id, "approved")
+
+            return SubmissionResult(
+                action_id=action.action_id,
+                track_id=action.track_id,
+                symbol=action.symbol,
+                status=SubmissionStatus.SUBMITTED,
+                client_order_id=client_order_id,
+                local_order_id=order.local_order_id,
+                risk_decision=decision,
+                risk_status_label="approved",
+            )
+
+    def submit_actions(
+        self, actions: Iterable[ActionItem],
+    ) -> tuple[SubmissionResult, ...]:
+        return tuple(self.submit_action(a) for a in actions)
+
+    def _build_portfolio_state(
+        self, session: Session, track: StrategyTrack,
+    ) -> PortfolioState:
+        return latest_state_from_snapshot(session=session, track=track)
+
+
+# --------------------------------------------------------------------------- #
+# Helpers
+# --------------------------------------------------------------------------- #
+_ACTION_SIDE_TO_INTENT: Final[dict[OrderSide, str]] = {
+    OrderSide.BUY: "buy",
+    OrderSide.SELL: "sell",
+    OrderSide.SELL_SHORT: "sell_short",
+    OrderSide.BUY_TO_COVER: "buy_to_cover",
+    OrderSide.MULTI_LEG: "multi_leg",
+}
+
+_ACTION_ORDER_TYPE_TO_INTENT: Final[dict[ActionOrderType, str]] = {
+    ActionOrderType.MARKET: "market",
+    ActionOrderType.LIMIT: "limit",
+    ActionOrderType.STOP: "stop",
+    ActionOrderType.STOP_LIMIT: "stop_limit",
+}
+
+
+def _action_to_intent(action: ActionItem) -> OrderIntent:
+    """Build a canonical :class:`OrderIntent` from an :class:`ActionItem`.
+
+    Multi-leg actions are out of scope for the Phase 5 MVP: we capture the
+    leg shape in :attr:`OrderIntent.legs` so the deterministic
+    ``client_order_id`` differs between leg structures, but the mock
+    broker treats them as a single notional ticket.
+    """
+
+    legs: tuple[tuple[str, str], ...] | None = None
+    if action.multi_leg is not None:
+        legs = tuple(
+            (leg.occ_symbol, leg.side.value) for leg in action.multi_leg.legs
+        )
+    return OrderIntent(
+        symbol=action.symbol,
+        side=_ACTION_SIDE_TO_INTENT[action.side],
+        order_type=_ACTION_ORDER_TYPE_TO_INTENT[action.order_type],
+        time_in_force=action.time_in_force,
+        qty=None,
+        notional=action.target_notional_usd,
+        limit_price=action.limit_price,
+        stop_price=action.stop_price,
+        legs=legs,
+    )
+
+
+def _persist_action_status(
+    repo: Repository, action_id: str, risk_status: str,
+) -> None:
+    """Best-effort risk_status persistence; missing rows are tolerated."""
+
+    repo.set_action_risk_status(action_id=action_id, risk_status=risk_status)
+
+
+def _stable_mock_price(symbol: str) -> Decimal:
+    """Deterministic per-symbol pseudo price in [10, 1000].
+
+    Lets the mock broker fill orders for any symbol without a live data
+    feed. The price is stable across runs so deterministic-ID tests stay
+    deterministic.
+    """
+
+    digest = hashlib.sha256(symbol.upper().encode("utf-8")).digest()
+    raw = int.from_bytes(digest[:4], "big")
+    # 10 .. 1010 USD
+    return Decimal(10 + raw % 1000) + Decimal("0.50")
+
+
+def _utcnow() -> dt.datetime:
+    return dt.datetime.now(dt.UTC)
+
+
+def _coerce_dt(value: object) -> dt.datetime:
+    if isinstance(value, dt.datetime):
+        return value if value.tzinfo else value.replace(tzinfo=dt.UTC)
+    if value is None:
+        return _utcnow()
+    return _utcnow()
+
+
+def _coerce_decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    try:
+        return Decimal(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+__all__ = (
+    "AlpacaPaperBrokerClient",
+    "BrokerClient",
+    "BrokerOrder",
+    "ExecutionAdapter",
+    "MockBrokerClient",
+    "SubmissionResult",
+    "SubmissionStatus",
+)

--- a/src/stockripper/risk/floors.py
+++ b/src/stockripper/risk/floors.py
@@ -1,0 +1,141 @@
+"""Universal floors (spec §16.1).
+
+These are the only hard limits that cannot be loosened by any track config
+or any judge. They run **before** the per-track risk gate and **before**
+the execution adapter ever touches an external endpoint.
+
+Failure modes:
+
+- :class:`FloorViolation` raised with a structured ``code`` so the caller
+  (typically the execution adapter) can persist a precise rejection
+  rationale on the ``decision_actions.risk_status`` column.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Final
+
+from stockripper.agents.schemas import ActionItem
+from stockripper.config import PaperEndpointError, StockripperSettings
+
+
+class FloorCode(StrEnum):
+    """Structured reason codes for universal-floor rejections."""
+
+    PAPER_ENDPOINT = "floor_paper_endpoint"
+    IDEMPOTENCY = "floor_idempotency"
+    SCHEMA_VALID = "floor_schema_valid"
+    NO_LLM_DIRECT = "floor_no_llm_direct"
+    AUDIT_COMPLETENESS = "floor_audit_completeness"
+    KILL_SWITCH = "floor_kill_switch"
+    TRACK_PAUSED = "floor_track_paused"
+
+
+class FloorViolation(RuntimeError):  # noqa: N818 - "Violation" reads better than "Error" for a floor
+    """One of the universal floors blocked an action."""
+
+    def __init__(self, code: FloorCode, message: str) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+
+    def __repr__(self) -> str:
+        return f"FloorViolation(code={self.code.value!r}, message={self.message!r})"
+
+
+@dataclass(frozen=True)
+class FloorContext:
+    """Inputs the floors check needs that are not on the action itself."""
+
+    kill_switch_engaged: bool
+    kill_reason: str | None
+    track_paused: bool
+    pause_reason: str | None
+    client_order_id: str | None
+    has_audit_row: bool
+
+
+# ``client_order_id`` may be at most 48 characters per Alpaca docs.
+_CLIENT_ORDER_ID_MAX_LEN: Final[int] = 48
+
+
+def check_floors(
+    *,
+    action: ActionItem,
+    context: FloorContext,
+    settings: StockripperSettings | None = None,
+) -> None:
+    """Run every universal floor against an action.
+
+    Raises :class:`FloorViolation` on the first failure. Order matters:
+    kill switch and pause are cheapest and should short-circuit before
+    we touch any other invariant.
+    """
+
+    if context.kill_switch_engaged:
+        raise FloorViolation(
+            FloorCode.KILL_SWITCH,
+            f"kill switch engaged: {context.kill_reason or 'unknown'}",
+        )
+
+    if context.track_paused:
+        raise FloorViolation(
+            FloorCode.TRACK_PAUSED,
+            f"track {action.track_id!r} is paused: {context.pause_reason or 'unknown'}",
+        )
+
+    if settings is not None:
+        try:
+            settings.assert_paper_only()
+        except PaperEndpointError as exc:
+            raise FloorViolation(FloorCode.PAPER_ENDPOINT, str(exc)) from exc
+
+    # Schema-validity floor: ActionItem is a frozen pydantic model with
+    # field validators, so by the time we receive one it has already
+    # passed schema validation. We re-assert key invariants here so a
+    # caller bypassing the schema cannot slip a malformed action in.
+    if not action.symbol or not action.symbol.strip():
+        raise FloorViolation(
+            FloorCode.SCHEMA_VALID,
+            f"action {action.action_id!r} has empty symbol",
+        )
+    if action.target_notional_usd is None and action.target_pct_equity is None:
+        raise FloorViolation(
+            FloorCode.SCHEMA_VALID,
+            f"action {action.action_id!r} has neither target_notional_usd "
+            "nor target_pct_equity",
+        )
+    if action.target_notional_usd is not None and action.target_pct_equity is not None:
+        raise FloorViolation(
+            FloorCode.SCHEMA_VALID,
+            f"action {action.action_id!r} sets both target_notional_usd "
+            "and target_pct_equity",
+        )
+
+    if context.client_order_id is None or not context.client_order_id.strip():
+        raise FloorViolation(
+            FloorCode.IDEMPOTENCY,
+            f"action {action.action_id!r} has no deterministic client_order_id",
+        )
+    if len(context.client_order_id) > _CLIENT_ORDER_ID_MAX_LEN:
+        raise FloorViolation(
+            FloorCode.IDEMPOTENCY,
+            f"client_order_id {context.client_order_id!r} exceeds "
+            f"{_CLIENT_ORDER_ID_MAX_LEN}-char Alpaca limit",
+        )
+
+    if not context.has_audit_row:
+        raise FloorViolation(
+            FloorCode.AUDIT_COMPLETENESS,
+            f"action {action.action_id!r} has no ledger row; refusing to submit",
+        )
+
+
+__all__ = (
+    "FloorCode",
+    "FloorContext",
+    "FloorViolation",
+    "check_floors",
+)

--- a/src/stockripper/risk/gate.py
+++ b/src/stockripper/risk/gate.py
@@ -1,0 +1,266 @@
+"""Per-track risk gate (spec §16.2).
+
+Evaluates a single :class:`ActionItem` against the per-track
+:class:`RiskPolicyParams` and current :class:`PortfolioState`. The output
+is a structured :class:`RiskDecision` (approved or rejected with reason
+codes) that the execution adapter persists onto
+``decision_actions.risk_status`` before submitting any order.
+
+Hard rule: the risk gate **never** mutates inputs and **never** decides
+on its own to submit anything. It only answers "is this allowed under
+this track's policy right now?".
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from enum import StrEnum
+from typing import Final
+
+from stockripper.agents.schemas import (
+    ActionItem,
+    OrderSide,
+    RecommendationInstrument,
+)
+from stockripper.risk import RiskPolicyParams
+from stockripper.risk.portfolio import PortfolioState
+
+_SHORT_SIDES: Final[frozenset[OrderSide]] = frozenset(
+    {OrderSide.SELL_SHORT, OrderSide.BUY_TO_COVER}
+)
+_OPTION_INSTRUMENTS: Final[frozenset[RecommendationInstrument]] = frozenset(
+    {RecommendationInstrument.OPTION_SINGLE, RecommendationInstrument.MULTI_LEG_OPTION}
+)
+
+
+class RiskDecisionStatus(StrEnum):
+    APPROVED = "approved"
+    REJECTED = "rejected"
+
+
+class RiskRejectionCode(StrEnum):
+    """Structured per-track rejection codes.
+
+    Distinct from :class:`stockripper.risk.floors.FloorCode`: floors are
+    universal invariants; these are per-track policy violations and can
+    be loosened by configuring the policy.
+    """
+
+    POSITION_PCT_EQUITY = "rt_position_pct_equity"
+    SHORT_DISALLOWED = "rt_short_disallowed"
+    SHORT_EXPOSURE_PCT_EQUITY = "rt_short_exposure_pct_equity"
+    OPTIONS_DISALLOWED = "rt_options_disallowed"
+    OPTIONS_NOTIONAL_PCT_EQUITY = "rt_options_notional_pct_equity"
+    LEVERAGED_ETF_DISALLOWED = "rt_leveraged_etf_disallowed"
+    GROSS_EXPOSURE_PCT_EQUITY = "rt_gross_exposure_pct_equity"
+    MAX_HOLDINGS = "rt_max_holdings"
+    SIZING_MISSING_PRICE = "rt_sizing_missing_price"
+
+
+@dataclass(frozen=True)
+class RiskRejection:
+    code: RiskRejectionCode
+    message: str
+    cap: Decimal | None = None
+    observed: Decimal | None = None
+
+
+@dataclass(frozen=True)
+class RiskDecision:
+    status: RiskDecisionStatus
+    rejections: tuple[RiskRejection, ...] = field(default_factory=tuple)
+    approved_notional_usd: Decimal | None = None
+    """The notional we would submit if approved (resolved from pct_equity if needed)."""
+
+    @property
+    def is_approved(self) -> bool:
+        return self.status is RiskDecisionStatus.APPROVED
+
+    @property
+    def is_rejected(self) -> bool:
+        return self.status is RiskDecisionStatus.REJECTED
+
+    def summary(self) -> str:
+        if self.is_approved:
+            return "approved"
+        codes = ",".join(r.code.value for r in self.rejections)
+        return f"rejected:{codes}"
+
+
+@dataclass(frozen=True)
+class RiskGate:
+    """Pure-evaluation gate. Construct once per policy; reuse per action."""
+
+    policy: RiskPolicyParams
+
+    def evaluate(
+        self,
+        *,
+        action: ActionItem,
+        portfolio: PortfolioState,
+    ) -> RiskDecision:
+        rejections: list[RiskRejection] = []
+        target_notional = _resolve_target_notional(action, portfolio)
+        if target_notional is None:
+            # Either both fields set (caught by schema) or pct given with
+            # equity == 0 — refuse on sizing.
+            return RiskDecision(
+                status=RiskDecisionStatus.REJECTED,
+                rejections=(
+                    RiskRejection(
+                        code=RiskRejectionCode.SIZING_MISSING_PRICE,
+                        message="cannot resolve target notional from action+portfolio",
+                    ),
+                ),
+            )
+
+        # --- per-position cap ---
+        position_cap = self.policy.max_position_pct_equity * portfolio.equity
+        if target_notional > position_cap:
+            rejections.append(
+                RiskRejection(
+                    code=RiskRejectionCode.POSITION_PCT_EQUITY,
+                    message=(
+                        f"target ${target_notional} exceeds "
+                        f"max_position_pct_equity={self.policy.max_position_pct_equity} "
+                        f"(cap ${position_cap})"
+                    ),
+                    cap=position_cap,
+                    observed=target_notional,
+                )
+            )
+
+        # --- short permissions ---
+        if action.side in _SHORT_SIDES:
+            short_cap = self.policy.max_short_exposure_pct_equity * portfolio.equity
+            if self.policy.max_short_exposure_pct_equity <= Decimal("0"):
+                rejections.append(
+                    RiskRejection(
+                        code=RiskRejectionCode.SHORT_DISALLOWED,
+                        message="track policy disallows short selling",
+                        cap=Decimal("0"),
+                        observed=target_notional,
+                    )
+                )
+            else:
+                projected_short = portfolio.short_exposure + target_notional
+                if projected_short > short_cap:
+                    rejections.append(
+                        RiskRejection(
+                            code=RiskRejectionCode.SHORT_EXPOSURE_PCT_EQUITY,
+                            message=(
+                                f"projected short exposure ${projected_short} exceeds "
+                                f"max_short_exposure_pct_equity="
+                                f"{self.policy.max_short_exposure_pct_equity} "
+                                f"(cap ${short_cap})"
+                            ),
+                            cap=short_cap,
+                            observed=projected_short,
+                        )
+                    )
+
+        # --- options permissions ---
+        if action.instrument in _OPTION_INSTRUMENTS:
+            options_cap = self.policy.max_options_notional_pct_equity * portfolio.equity
+            if self.policy.max_options_notional_pct_equity <= Decimal("0"):
+                rejections.append(
+                    RiskRejection(
+                        code=RiskRejectionCode.OPTIONS_DISALLOWED,
+                        message="track policy disallows options",
+                        cap=Decimal("0"),
+                        observed=target_notional,
+                    )
+                )
+            else:
+                projected_opt = portfolio.options_notional + target_notional
+                if projected_opt > options_cap:
+                    rejections.append(
+                        RiskRejection(
+                            code=RiskRejectionCode.OPTIONS_NOTIONAL_PCT_EQUITY,
+                            message=(
+                                f"projected options notional ${projected_opt} exceeds "
+                                f"max_options_notional_pct_equity="
+                                f"{self.policy.max_options_notional_pct_equity} "
+                                f"(cap ${options_cap})"
+                            ),
+                            cap=options_cap,
+                            observed=projected_opt,
+                        )
+                    )
+
+        # --- leveraged ETF permission ---
+        if action.instrument == RecommendationInstrument.LEVERAGED_ETF and not self.policy.leveraged_etf_allowed:
+            rejections.append(
+                RiskRejection(
+                    code=RiskRejectionCode.LEVERAGED_ETF_DISALLOWED,
+                    message="track policy disallows leveraged ETFs",
+                )
+            )
+
+        # --- gross exposure cap (after this action) ---
+        gross_cap = self.policy.max_gross_exposure_pct_equity * portfolio.equity
+        projected_gross = portfolio.gross_exposure + target_notional
+        if projected_gross > gross_cap:
+            rejections.append(
+                RiskRejection(
+                    code=RiskRejectionCode.GROSS_EXPOSURE_PCT_EQUITY,
+                    message=(
+                        f"projected gross exposure ${projected_gross} exceeds "
+                        f"max_gross_exposure_pct_equity="
+                        f"{self.policy.max_gross_exposure_pct_equity} "
+                        f"(cap ${gross_cap})"
+                    ),
+                    cap=gross_cap,
+                    observed=projected_gross,
+                )
+            )
+
+        # --- max holdings (after this action, only for opening a new position) ---
+        if portfolio.position(action.symbol) is None and action.side in {
+            OrderSide.BUY,
+            OrderSide.SELL_SHORT,
+        }:
+            projected_holdings = len(portfolio.positions) + 1
+            if projected_holdings > self.policy.max_holdings:
+                rejections.append(
+                    RiskRejection(
+                        code=RiskRejectionCode.MAX_HOLDINGS,
+                        message=(
+                            f"projected holdings count {projected_holdings} exceeds "
+                            f"max_holdings={self.policy.max_holdings}"
+                        ),
+                        cap=Decimal(self.policy.max_holdings),
+                        observed=Decimal(projected_holdings),
+                    )
+                )
+
+        if rejections:
+            return RiskDecision(
+                status=RiskDecisionStatus.REJECTED,
+                rejections=tuple(rejections),
+            )
+        return RiskDecision(
+            status=RiskDecisionStatus.APPROVED,
+            approved_notional_usd=target_notional,
+        )
+
+
+def _resolve_target_notional(
+    action: ActionItem,
+    portfolio: PortfolioState,
+) -> Decimal | None:
+    if action.target_notional_usd is not None:
+        return action.target_notional_usd
+    if action.target_pct_equity is not None and portfolio.equity > 0:
+        return (action.target_pct_equity * portfolio.equity).quantize(Decimal("0.01"))
+    return None
+
+
+__all__ = (
+    "RiskDecision",
+    "RiskDecisionStatus",
+    "RiskGate",
+    "RiskRejection",
+    "RiskRejectionCode",
+)

--- a/src/stockripper/risk/portfolio.py
+++ b/src/stockripper/risk/portfolio.py
@@ -1,0 +1,132 @@
+"""Lightweight per-track portfolio state used by the risk gate (Phase 5).
+
+We deliberately keep this minimal for the MVP: just enough fields that the
+gate's per-track caps (``max_position_pct_equity``,
+``max_short_exposure_pct_equity``, etc.) have something concrete to evaluate
+against. A full position-aware model lands in Phase 6+ when shadow
+portfolios come online.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from decimal import Decimal
+
+from sqlalchemy.orm import Session
+
+from stockripper.db.models import StrategyTrack
+from stockripper.db.repository import Repository
+
+
+@dataclass(frozen=True)
+class Position:
+    """One open position contributing to a track's exposure."""
+
+    symbol: str
+    qty: Decimal
+    market_value: Decimal
+    """Signed market value (negative for shorts)."""
+    is_option: bool = False
+    is_leveraged_etf: bool = False
+
+
+@dataclass(frozen=True)
+class PortfolioState:
+    """Snapshot a risk gate evaluates an action against.
+
+    All ``Decimal`` fields are in account currency (USD for Alpaca paper).
+    ``equity`` is the headline number against which every per-track cap
+    is expressed as a fraction.
+    """
+
+    track_id: str
+    equity: Decimal
+    cash: Decimal
+    positions: tuple[Position, ...] = field(default_factory=tuple)
+    captured_at: dt.datetime | None = None
+
+    @property
+    def gross_exposure(self) -> Decimal:
+        return sum((abs(p.market_value) for p in self.positions), start=Decimal("0"))
+
+    @property
+    def net_exposure(self) -> Decimal:
+        return sum((p.market_value for p in self.positions), start=Decimal("0"))
+
+    @property
+    def short_exposure(self) -> Decimal:
+        return sum(
+            (-p.market_value for p in self.positions if p.market_value < 0),
+            start=Decimal("0"),
+        )
+
+    @property
+    def options_notional(self) -> Decimal:
+        return sum(
+            (abs(p.market_value) for p in self.positions if p.is_option),
+            start=Decimal("0"),
+        )
+
+    @property
+    def leveraged_etf_notional(self) -> Decimal:
+        return sum(
+            (abs(p.market_value) for p in self.positions if p.is_leveraged_etf),
+            start=Decimal("0"),
+        )
+
+    def position(self, symbol: str) -> Position | None:
+        for p in self.positions:
+            if p.symbol.upper() == symbol.upper():
+                return p
+        return None
+
+
+def starting_equity_state(track: StrategyTrack) -> PortfolioState:
+    """Construct a flat PortfolioState from a strategy track's starting equity.
+
+    Useful for the very first window, before any snapshot has been recorded.
+    """
+
+    return PortfolioState(
+        track_id=track.track_id,
+        equity=track.starting_equity_usd,
+        cash=track.starting_equity_usd,
+        positions=(),
+    )
+
+
+def latest_state_from_snapshot(
+    *,
+    session: Session,
+    track: StrategyTrack,
+    positions: Iterable[Position] | None = None,
+) -> PortfolioState:
+    """Build a PortfolioState from the most recent ``track_snapshots`` row.
+
+    Falls back to :func:`starting_equity_state` when no snapshot has been
+    recorded yet. ``positions`` is an optional override for callers that
+    already have a populated position list (e.g. the execution adapter
+    threading post-reconciliation positions through).
+    """
+
+    repo = Repository(session)
+    snap = repo.latest_track_snapshot(track.track_id)
+    if snap is None:
+        return starting_equity_state(track)
+    return PortfolioState(
+        track_id=track.track_id,
+        equity=snap.equity,
+        cash=snap.cash,
+        positions=tuple(positions or ()),
+        captured_at=snap.captured_at,
+    )
+
+
+__all__ = (
+    "PortfolioState",
+    "Position",
+    "latest_state_from_snapshot",
+    "starting_equity_state",
+)

--- a/tests/test_execution_adapter.py
+++ b/tests/test_execution_adapter.py
@@ -1,0 +1,332 @@
+"""Tests for the Phase-5 execution adapter (spec §16.1, §25 Phase 5)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.agents.schemas import (
+    ActionItem,
+    ActionOrderType,
+    OrderSide,
+    RecommendationInstrument,
+)
+from stockripper.db import Base, Repository, build_engine
+from stockripper.db.models import DecisionAction, Fill, JudgeDecision, Order, Run
+from stockripper.execution.adapter import (
+    ExecutionAdapter,
+    MockBrokerClient,
+    SubmissionStatus,
+)
+from stockripper.tracks import seed_default_tracks
+
+_FROZEN_NOW = dt.datetime(2026, 5, 28, 14, 30, 0, tzinfo=dt.UTC)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+@pytest.fixture
+def session_factory() -> sessionmaker[Session]:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    with factory() as s:
+        seed_default_tracks(s)
+        s.commit()
+    return factory
+
+
+def _seed_run_decision_action(
+    factory: sessionmaker[Session],
+    *,
+    action_id: str = "act_test",
+    track_id: str = "balanced",
+    symbol: str = "AAPL",
+    side: OrderSide = OrderSide.BUY,
+    instrument: RecommendationInstrument = RecommendationInstrument.EQUITY,
+    target_notional_usd: Decimal | None = Decimal("1000"),
+    target_pct_equity: Decimal | None = None,
+) -> None:
+    """Pre-create a Run + JudgeDecision + DecisionAction row so the
+    universal audit-completeness floor passes."""
+
+    with factory() as s:
+        run = Run(
+            run_id="run_test",
+            trading_day=_FROZEN_NOW.date(),
+            window_label="adhoc",
+            status="ok",
+            started_at=_FROZEN_NOW,
+            completed_at=_FROZEN_NOW,
+            config_hash="cfg-test",
+        )
+        s.add(run)
+        decision = JudgeDecision(
+            decision_id="dec_test",
+            run_id="run_test",
+            track_id=track_id,
+            judge_agent_id="judge_x",
+            portfolio_posture="cash",
+            created_at=_FROZEN_NOW,
+        )
+        s.add(decision)
+        s.flush()
+        action_row = DecisionAction(
+            action_id=action_id,
+            decision_id="dec_test",
+            track_id=track_id,
+            symbol=symbol,
+            instrument_type=instrument.value,
+            action=side.value,
+            target_notional_usd=target_notional_usd,
+            target_pct_equity=target_pct_equity,
+            order_type=ActionOrderType.MARKET.value,
+            time_in_force="day",
+            rationale="test",
+        )
+        s.add(action_row)
+        s.commit()
+
+
+def _action(
+    *,
+    action_id: str = "act_test",
+    track_id: str = "balanced",
+    symbol: str = "AAPL",
+    side: OrderSide = OrderSide.BUY,
+    instrument: RecommendationInstrument = RecommendationInstrument.EQUITY,
+    target_notional_usd: Decimal | None = Decimal("1000"),
+    target_pct_equity: Decimal | None = None,
+) -> ActionItem:
+    kwargs: dict[str, object] = {
+        "action_id": action_id,
+        "track_id": track_id,
+        "symbol": symbol,
+        "instrument": instrument,
+        "side": side,
+        "order_type": ActionOrderType.MARKET,
+        "rationale": "test",
+    }
+    if target_notional_usd is not None:
+        kwargs["target_notional_usd"] = target_notional_usd
+    if target_pct_equity is not None:
+        kwargs["target_pct_equity"] = target_pct_equity
+    return ActionItem(**kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Happy path
+# ---------------------------------------------------------------------------
+def test_adapter_submits_through_mock_broker(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _seed_run_decision_action(session_factory)
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    result = adapter.submit_action(_action())
+
+    assert result.status == SubmissionStatus.SUBMITTED
+    assert result.client_order_id is not None
+    assert result.local_order_id is not None
+    assert result.risk_status_label == "approved"
+
+    with session_factory() as s:
+        repo = Repository(s)
+        orders = repo.list_orders_for_track(track_id="balanced")
+        assert len(orders) == 1
+        order = orders[0]
+        assert order.client_order_id == result.client_order_id
+        assert order.symbol == "AAPL"
+        assert order.status == "filled"
+        # MockBroker synthesizes a fill -> Fill row present.
+        fills = s.query(Fill).filter(Fill.local_order_id == order.local_order_id).all()
+        assert len(fills) == 1
+        assert fills[0].filled_avg_price > 0
+        # The action row's risk_status should now be 'approved'.
+        action_row = s.get(DecisionAction, "act_test")
+        assert action_row is not None
+        assert action_row.risk_status == "approved"
+
+
+# ---------------------------------------------------------------------------
+# Idempotency
+# ---------------------------------------------------------------------------
+def test_adapter_duplicate_collapses_via_client_order_id(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _seed_run_decision_action(session_factory)
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    first = adapter.submit_action(_action())
+    second = adapter.submit_action(_action())
+
+    assert first.status == SubmissionStatus.SUBMITTED
+    assert second.status == SubmissionStatus.DUPLICATE
+    assert first.client_order_id == second.client_order_id
+    assert first.local_order_id == second.local_order_id
+
+    with session_factory() as s:
+        orders = s.query(Order).all()
+        assert len(orders) == 1  # No duplicate row.
+
+
+# ---------------------------------------------------------------------------
+# Floor enforcement
+# ---------------------------------------------------------------------------
+def test_adapter_blocked_by_mid_window_kill_switch(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _seed_run_decision_action(session_factory)
+
+    # Kill switch engaged AFTER the run/decision/action rows already exist.
+    with session_factory() as s:
+        repo = Repository(s)
+        repo.engage_kill_switch(reason="ops_drill", engaged_by="test")
+        s.commit()
+
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    result = adapter.submit_action(_action())
+
+    assert result.status == SubmissionStatus.REJECTED_FLOOR
+    assert result.risk_status_label == "rejected_floor:floor_kill_switch"
+    assert result.local_order_id is None
+
+    with session_factory() as s:
+        assert s.query(Order).count() == 0
+        action_row = s.get(DecisionAction, "act_test")
+        assert action_row is not None
+        assert action_row.risk_status == "rejected_floor:floor_kill_switch"
+
+
+def test_adapter_blocked_by_track_pause(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _seed_run_decision_action(session_factory)
+    with session_factory() as s:
+        repo = Repository(s)
+        repo.pause_track(track_id="balanced", reason="manual")
+        s.commit()
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    result = adapter.submit_action(_action())
+    assert result.status == SubmissionStatus.REJECTED_FLOOR
+    assert "track_paused" in result.risk_status_label
+
+
+def test_adapter_rejects_unknown_track(
+    session_factory: sessionmaker[Session],
+) -> None:
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    # No matching strategy_tracks row -> floor rejection.
+    result = adapter.submit_action(
+        _action(track_id="ghost_track"),
+    )
+    assert result.status == SubmissionStatus.REJECTED_FLOOR
+    assert "unknown_track:ghost_track" in result.risk_status_label
+
+
+# ---------------------------------------------------------------------------
+# Risk gate enforcement
+# ---------------------------------------------------------------------------
+def test_adapter_persists_risk_status_on_gate_rejection(
+    session_factory: sessionmaker[Session],
+) -> None:
+    # Balanced cap is 7% of $100k = $7k. $10k breaches it.
+    _seed_run_decision_action(
+        session_factory, target_notional_usd=Decimal("10000"),
+    )
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    result = adapter.submit_action(
+        _action(target_notional_usd=Decimal("10000")),
+    )
+    assert result.status == SubmissionStatus.REJECTED_RISK
+    assert "rt_position_pct_equity" in result.risk_status_label
+    assert result.local_order_id is None
+
+    with session_factory() as s:
+        # Nothing was submitted to the broker.
+        assert s.query(Order).count() == 0
+        action_row = s.get(DecisionAction, "act_test")
+        assert action_row is not None
+        assert action_row.risk_status is not None
+        assert "rt_position_pct_equity" in action_row.risk_status
+
+
+def test_adapter_rejects_short_on_no_short_policy(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _seed_run_decision_action(
+        session_factory, side=OrderSide.SELL_SHORT,
+    )
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    result = adapter.submit_action(_action(side=OrderSide.SELL_SHORT))
+    assert result.status == SubmissionStatus.REJECTED_RISK
+    assert "rt_short_disallowed" in result.risk_status_label
+
+
+# ---------------------------------------------------------------------------
+# Deterministic client_order_id
+# ---------------------------------------------------------------------------
+def test_same_intent_in_different_window_gets_different_coid(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _seed_run_decision_action(session_factory)
+    adapter_a = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    adapter_b = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="midday",
+    )
+    res_a = adapter_a.submit_action(_action())
+    res_b = adapter_b.submit_action(_action())
+    assert res_a.client_order_id != res_b.client_order_id
+    assert res_a.status == SubmissionStatus.SUBMITTED
+    # The second submission is in a different window so it is a NEW order, not a duplicate.
+    assert res_b.status == SubmissionStatus.SUBMITTED
+
+
+def test_same_intent_same_window_collapses(
+    session_factory: sessionmaker[Session],
+) -> None:
+    _seed_run_decision_action(session_factory)
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    first = adapter.submit_action(_action())
+    second = adapter.submit_action(_action())
+    assert first.client_order_id == second.client_order_id

--- a/tests/test_risk_floors.py
+++ b/tests/test_risk_floors.py
@@ -1,0 +1,142 @@
+"""Tests for the universal floors (spec §16.1)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+
+from stockripper.agents.schemas import (
+    ActionItem,
+    ActionOrderType,
+    OrderSide,
+    RecommendationInstrument,
+)
+from stockripper.risk.floors import (
+    FloorCode,
+    FloorContext,
+    FloorViolation,
+    check_floors,
+)
+
+
+def _make_action(**overrides: object) -> ActionItem:
+    defaults: dict[str, object] = {
+        "action_id": "act_test",
+        "track_id": "balanced",
+        "symbol": "AAPL",
+        "instrument": RecommendationInstrument.EQUITY,
+        "side": OrderSide.BUY,
+        "target_notional_usd": Decimal("1000"),
+        "order_type": ActionOrderType.MARKET,
+        "rationale": "test buy",
+    }
+    defaults.update(overrides)
+    return ActionItem(**defaults)  # type: ignore[arg-type]
+
+
+def _ctx(**overrides: object) -> FloorContext:
+    defaults: dict[str, object] = {
+        "kill_switch_engaged": False,
+        "kill_reason": None,
+        "track_paused": False,
+        "pause_reason": None,
+        "client_order_id": "coid_balanced_abc123",
+        "has_audit_row": True,
+    }
+    defaults.update(overrides)
+    return FloorContext(**defaults)  # type: ignore[arg-type]
+
+
+def test_floor_blocks_when_kill_switch_engaged() -> None:
+    with pytest.raises(FloorViolation) as exc_info:
+        check_floors(
+            action=_make_action(),
+            context=_ctx(kill_switch_engaged=True, kill_reason="ops_drill"),
+        )
+    assert exc_info.value.code == FloorCode.KILL_SWITCH
+    assert "ops_drill" in exc_info.value.message
+
+
+def test_floor_blocks_when_track_paused() -> None:
+    with pytest.raises(FloorViolation) as exc_info:
+        check_floors(
+            action=_make_action(),
+            context=_ctx(track_paused=True, pause_reason="manual"),
+        )
+    assert exc_info.value.code == FloorCode.TRACK_PAUSED
+
+
+def test_floor_blocks_when_client_order_id_missing() -> None:
+    with pytest.raises(FloorViolation) as exc_info:
+        check_floors(
+            action=_make_action(),
+            context=_ctx(client_order_id=None),
+        )
+    assert exc_info.value.code == FloorCode.IDEMPOTENCY
+
+
+def test_floor_blocks_when_client_order_id_too_long() -> None:
+    with pytest.raises(FloorViolation) as exc_info:
+        check_floors(
+            action=_make_action(),
+            context=_ctx(client_order_id="x" * 49),
+        )
+    assert exc_info.value.code == FloorCode.IDEMPOTENCY
+
+
+def test_floor_blocks_when_audit_row_missing() -> None:
+    with pytest.raises(FloorViolation) as exc_info:
+        check_floors(
+            action=_make_action(),
+            context=_ctx(has_audit_row=False),
+        )
+    assert exc_info.value.code == FloorCode.AUDIT_COMPLETENESS
+
+
+def test_floor_passes_for_well_formed_action() -> None:
+    # Should not raise.
+    check_floors(action=_make_action(), context=_ctx())
+
+
+def test_floor_blocks_when_paper_endpoint_invariant_violated() -> None:
+    """The paper-endpoint floor delegates to ``StockripperSettings``.
+
+    We exercise that delegation by passing a settings stub whose
+    ``assert_paper_only`` raises :class:`PaperEndpointError`.
+    """
+
+    from stockripper.config import PaperEndpointError
+
+    class _BadSettings:
+        def assert_paper_only(self) -> None:
+            raise PaperEndpointError("non-paper endpoint configured")
+
+    with pytest.raises(FloorViolation) as exc_info:
+        check_floors(
+            action=_make_action(),
+            context=_ctx(),
+            settings=_BadSettings(),  # type: ignore[arg-type]
+        )
+    assert exc_info.value.code == FloorCode.PAPER_ENDPOINT
+
+
+def test_floor_freezes_context() -> None:
+    """FloorContext should be a frozen dataclass to avoid mid-check mutation."""
+
+    from dataclasses import FrozenInstanceError
+
+    ctx = _ctx()
+    with pytest.raises(FrozenInstanceError):
+        ctx.kill_switch_engaged = True  # type: ignore[misc]
+
+
+def test_floor_violation_repr_includes_code_and_message() -> None:
+    v = FloorViolation(FloorCode.KILL_SWITCH, "kill engaged")
+    assert "floor_kill_switch" in repr(v)
+    assert "kill engaged" in repr(v)
+
+
+# Suppress the unused-import warning from pytest using the module.
+_ = dt

--- a/tests/test_risk_gate.py
+++ b/tests/test_risk_gate.py
@@ -1,0 +1,244 @@
+"""Tests for the per-track risk gate (spec §16.2)."""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+from stockripper.agents.schemas import (
+    ActionItem,
+    ActionOrderType,
+    OrderSide,
+    RecommendationInstrument,
+)
+from stockripper.risk import DEFAULT_RISK_POLICIES, RiskPolicyParams
+from stockripper.risk.gate import RiskGate, RiskRejectionCode
+from stockripper.risk.portfolio import PortfolioState, Position
+
+
+def _flat_portfolio(equity: Decimal = Decimal("100000")) -> PortfolioState:
+    return PortfolioState(track_id="balanced", equity=equity, cash=equity)
+
+
+def _action(
+    *,
+    instrument: RecommendationInstrument = RecommendationInstrument.EQUITY,
+    side: OrderSide = OrderSide.BUY,
+    target_notional_usd: Decimal | None = Decimal("1000"),
+    target_pct_equity: Decimal | None = None,
+    symbol: str = "AAPL",
+) -> ActionItem:
+    kwargs: dict[str, object] = {
+        "action_id": "act_x",
+        "track_id": "balanced",
+        "symbol": symbol,
+        "instrument": instrument,
+        "side": side,
+        "order_type": ActionOrderType.MARKET,
+        "rationale": "test",
+    }
+    if target_notional_usd is not None:
+        kwargs["target_notional_usd"] = target_notional_usd
+    if target_pct_equity is not None:
+        kwargs["target_pct_equity"] = target_pct_equity
+    return ActionItem(**kwargs)  # type: ignore[arg-type]
+
+
+def test_gate_approves_within_caps() -> None:
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_balanced"])
+    decision = gate.evaluate(
+        action=_action(target_notional_usd=Decimal("5000")),
+        portfolio=_flat_portfolio(),
+    )
+    assert decision.is_approved
+    assert decision.approved_notional_usd == Decimal("5000")
+    assert decision.summary() == "approved"
+
+
+def test_gate_resolves_pct_equity_to_notional() -> None:
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_balanced"])
+    decision = gate.evaluate(
+        action=_action(
+            target_notional_usd=None,
+            target_pct_equity=Decimal("0.05"),
+        ),
+        portfolio=_flat_portfolio(Decimal("100000")),
+    )
+    assert decision.is_approved
+    assert decision.approved_notional_usd == Decimal("5000.00")
+
+
+def test_gate_rejects_oversized_position() -> None:
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_balanced"])
+    # Balanced cap is 7% of equity. $10k on $100k portfolio = 10%.
+    decision = gate.evaluate(
+        action=_action(target_notional_usd=Decimal("10000")),
+        portfolio=_flat_portfolio(),
+    )
+    assert decision.is_rejected
+    codes = {r.code for r in decision.rejections}
+    assert RiskRejectionCode.POSITION_PCT_EQUITY in codes
+
+
+def test_gate_rejects_short_when_disallowed() -> None:
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_balanced"])
+    decision = gate.evaluate(
+        action=_action(side=OrderSide.SELL_SHORT),
+        portfolio=_flat_portfolio(),
+    )
+    assert decision.is_rejected
+    codes = {r.code for r in decision.rejections}
+    assert RiskRejectionCode.SHORT_DISALLOWED in codes
+
+
+def test_gate_rejects_options_when_disallowed() -> None:
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_conservative"])
+    decision = gate.evaluate(
+        action=_action(instrument=RecommendationInstrument.OPTION_SINGLE),
+        portfolio=_flat_portfolio(),
+    )
+    assert decision.is_rejected
+    codes = {r.code for r in decision.rejections}
+    assert RiskRejectionCode.OPTIONS_DISALLOWED in codes
+
+
+def test_gate_rejects_leveraged_etf_when_disallowed() -> None:
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_balanced"])
+    decision = gate.evaluate(
+        action=_action(instrument=RecommendationInstrument.LEVERAGED_ETF),
+        portfolio=_flat_portfolio(),
+    )
+    assert decision.is_rejected
+    codes = {r.code for r in decision.rejections}
+    assert RiskRejectionCode.LEVERAGED_ETF_DISALLOWED in codes
+
+
+def test_gate_approves_leveraged_etf_when_allowed() -> None:
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_aggressive"])
+    decision = gate.evaluate(
+        action=_action(instrument=RecommendationInstrument.LEVERAGED_ETF),
+        portfolio=_flat_portfolio(),
+    )
+    assert decision.is_approved
+
+
+def test_gate_rejects_when_short_cap_breached() -> None:
+    # Aggressive policy allows shorts up to 50% of equity.
+    gate = RiskGate(policy=DEFAULT_RISK_POLICIES["rp_aggressive"])
+    # Existing short positions already at 49% of $100k.
+    portfolio = PortfolioState(
+        track_id="aggressive",
+        equity=Decimal("100000"),
+        cash=Decimal("100000"),
+        positions=(
+            Position(
+                symbol="SPY",
+                qty=Decimal("-100"),
+                market_value=Decimal("-49000"),
+            ),
+        ),
+    )
+    decision = gate.evaluate(
+        action=_action(
+            side=OrderSide.SELL_SHORT,
+            symbol="QQQ",
+            target_notional_usd=Decimal("5000"),
+        ),
+        portfolio=portfolio,
+    )
+    assert decision.is_rejected
+    codes = {r.code for r in decision.rejections}
+    assert RiskRejectionCode.SHORT_EXPOSURE_PCT_EQUITY in codes
+
+
+def test_gate_rejects_when_max_holdings_exceeded() -> None:
+    """Opening a new position when already at the per-track holdings cap."""
+
+    policy = RiskPolicyParams(
+        max_position_pct_equity=Decimal("0.50"),
+        min_holdings=1,
+        max_holdings=2,
+        max_gross_exposure_pct_equity=Decimal("4.00"),
+        max_short_exposure_pct_equity=Decimal("0.00"),
+        max_options_notional_pct_equity=Decimal("0.00"),
+        leveraged_etf_allowed=False,
+        judge_objective="return",
+    )
+    gate = RiskGate(policy=policy)
+    portfolio = PortfolioState(
+        track_id="t",
+        equity=Decimal("100000"),
+        cash=Decimal("50000"),
+        positions=(
+            Position(symbol="AAPL", qty=Decimal("10"), market_value=Decimal("2000")),
+            Position(symbol="MSFT", qty=Decimal("5"), market_value=Decimal("1500")),
+        ),
+    )
+    decision = gate.evaluate(
+        action=_action(symbol="GOOG", target_notional_usd=Decimal("1000")),
+        portfolio=portfolio,
+    )
+    assert decision.is_rejected
+    codes = {r.code for r in decision.rejections}
+    assert RiskRejectionCode.MAX_HOLDINGS in codes
+
+
+def test_gate_allows_adding_to_existing_position_at_max_holdings() -> None:
+    """Buying more of an already-held name should not trip max_holdings."""
+
+    policy = RiskPolicyParams(
+        max_position_pct_equity=Decimal("0.50"),
+        min_holdings=1,
+        max_holdings=2,
+        max_gross_exposure_pct_equity=Decimal("4.00"),
+        max_short_exposure_pct_equity=Decimal("0.00"),
+        max_options_notional_pct_equity=Decimal("0.00"),
+        leveraged_etf_allowed=False,
+        judge_objective="return",
+    )
+    gate = RiskGate(policy=policy)
+    portfolio = PortfolioState(
+        track_id="t",
+        equity=Decimal("100000"),
+        cash=Decimal("50000"),
+        positions=(
+            Position(symbol="AAPL", qty=Decimal("10"), market_value=Decimal("2000")),
+            Position(symbol="MSFT", qty=Decimal("5"), market_value=Decimal("1500")),
+        ),
+    )
+    # Adding to AAPL (already held), not opening a new name.
+    decision = gate.evaluate(
+        action=_action(symbol="AAPL", target_notional_usd=Decimal("1000")),
+        portfolio=portfolio,
+    )
+    assert decision.is_approved
+
+
+def test_gate_rejects_when_gross_exposure_cap_breached() -> None:
+    """Gross-exposure cap protects against fully-margined chaining."""
+
+    policy = RiskPolicyParams(
+        max_position_pct_equity=Decimal("1.00"),
+        min_holdings=1,
+        max_holdings=20,
+        max_gross_exposure_pct_equity=Decimal("1.00"),
+        max_short_exposure_pct_equity=Decimal("0.00"),
+        max_options_notional_pct_equity=Decimal("0.00"),
+        leveraged_etf_allowed=False,
+        judge_objective="return",
+    )
+    gate = RiskGate(policy=policy)
+    portfolio = PortfolioState(
+        track_id="t",
+        equity=Decimal("100000"),
+        cash=Decimal("5000"),
+        positions=(
+            Position(symbol="SPY", qty=Decimal("200"), market_value=Decimal("95000")),
+        ),
+    )
+    decision = gate.evaluate(
+        action=_action(symbol="QQQ", target_notional_usd=Decimal("10000")),
+        portfolio=portfolio,
+    )
+    assert decision.is_rejected
+    codes = {r.code for r in decision.rejections}
+    assert RiskRejectionCode.GROSS_EXPOSURE_PCT_EQUITY in codes

--- a/tests/test_window_runner.py
+++ b/tests/test_window_runner.py
@@ -19,6 +19,7 @@ from sqlalchemy.orm import Session, sessionmaker
 from stockripper.agents.canned_llm import CannedCouncilLLM
 from stockripper.agents.registry import build_registry
 from stockripper.agents.schemas import EvidencePacket
+from stockripper.agents.schemas import JudgeDecision as JudgeDecisionSchema
 from stockripper.agents.window_runner import run_window
 from stockripper.db import Base, Repository, build_engine
 from stockripper.db.models import AgentRun, JudgeDecision, Run, TrackRun
@@ -253,3 +254,184 @@ async def test_run_window_no_persist_skips_db(
     # No rows should exist in our fixture DB.
     with session_factory() as s:
         assert s.query(Run).filter(Run.run_id == result.run_id).one_or_none() is None
+
+
+# --------------------------------------------------------------------------- #
+# Phase 5 — execution wiring
+# --------------------------------------------------------------------------- #
+class _BuyingCannedLLM(CannedCouncilLLM):
+    """Variant that emits a single small BUY action so the execution
+    adapter has something concrete to submit."""
+
+    def _make_judge_decision(self, agent_id: str) -> JudgeDecisionSchema:
+        from decimal import Decimal
+
+        from stockripper.agents.schemas import (
+            ActionItem,
+            ActionOrderType,
+            ActionPlan,
+            OrderSide,
+            PortfolioPosture,
+            RecommendationInstrument,
+        )
+
+        packet = self._require_packet(agent_id)
+        when = self._moment()
+        seed = self._stable_id_seed(agent_id, "plan", packet.symbol)
+        item = ActionItem(
+            action_id=f"act_{seed}",
+            track_id=packet.track_id,
+            symbol=packet.symbol,
+            instrument=RecommendationInstrument.EQUITY,
+            side=OrderSide.BUY,
+            target_notional_usd=Decimal("500"),
+            order_type=ActionOrderType.MARKET,
+            rationale=f"[canned-buy] {agent_id}: smoke buy for execution test.",
+        )
+        plan = ActionPlan(
+            decision_id=f"plan_{seed}",
+            track_id=packet.track_id,
+            judge_agent_id=agent_id,
+            judge_agent_version="1.0.0",
+            portfolio_posture=PortfolioPosture.NET_LONG,
+            items=(item,),
+            rationale="[canned-buy] one small BUY for the execution smoke test.",
+            objective_label="offline_canned_judge",
+            created_at=when,
+        )
+        return JudgeDecisionSchema(plan=plan, provenance=None)
+
+
+def _buying_llm_factory(packet: EvidencePacket) -> _BuyingCannedLLM:
+    return _BuyingCannedLLM(packet=packet, clock=_FROZEN_NOW)
+
+
+async def test_run_window_with_execution_adapter_writes_orders_and_fills(
+    session_factory: sessionmaker[Session],
+) -> None:
+    """End-to-end: run a one-track window through the mock execution adapter
+    and verify orders + fills land in the ledger, plus the action's
+    risk_status is 'approved'."""
+
+    from stockripper.db.models import DecisionAction, Fill, Order
+    from stockripper.execution.adapter import (
+        ExecutionAdapter,
+        MockBrokerClient,
+        SubmissionStatus,
+    )
+
+    registry = build_registry()
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced",),
+        symbols=("AAPL",),
+        window_label="opening",
+        config_hash="cfg-exec",
+        rng_seed=11,
+        now=_FROZEN_NOW,
+        llm_factory=_buying_llm_factory,
+        session_factory=session_factory,
+        execution_adapter=adapter,
+    )
+    assert result.status == "ok"
+    assert len(result.submissions) == 1
+    sub = result.submissions[0]
+    assert sub.status == SubmissionStatus.SUBMITTED
+    assert sub.track_id == "balanced"
+    assert sub.client_order_id is not None
+
+    with session_factory() as s:
+        orders = s.query(Order).all()
+        assert len(orders) == 1
+        fills = s.query(Fill).all()
+        assert len(fills) == 1
+        action_rows = s.query(DecisionAction).all()
+        assert len(action_rows) == 1
+        assert action_rows[0].risk_status == "approved"
+
+
+async def test_run_window_execution_idempotent_on_replay(
+    session_factory: sessionmaker[Session],
+) -> None:
+    """Re-running the same window with the same inputs collapses onto the
+    existing order via deterministic client_order_id."""
+
+    from stockripper.db.models import Order
+    from stockripper.execution.adapter import (
+        ExecutionAdapter,
+        MockBrokerClient,
+        SubmissionStatus,
+    )
+
+    registry = build_registry()
+
+    async def _drive() -> tuple[str, str | None]:
+        adapter = ExecutionAdapter(
+            session_factory=session_factory,
+            broker=MockBrokerClient(now=_FROZEN_NOW),
+            window_id="opening",
+        )
+        result = await run_window(
+            registry=registry,
+            track_ids=("balanced",),
+            symbols=("AAPL",),
+            window_label="opening",
+            config_hash="cfg-exec-replay",
+            rng_seed=11,
+            now=_FROZEN_NOW,
+            llm_factory=_buying_llm_factory,
+            session_factory=session_factory,
+            execution_adapter=adapter,
+        )
+        sub = result.submissions[0]
+        return sub.status.value, sub.client_order_id
+
+    status_a, coid_a = await _drive()
+    status_b, coid_b = await _drive()
+
+    assert coid_a == coid_b
+    assert status_a == SubmissionStatus.SUBMITTED.value
+    assert status_b == SubmissionStatus.DUPLICATE.value
+
+    with session_factory() as s:
+        orders = s.query(Order).all()
+        assert len(orders) == 1  # Idempotent — no duplicate row.
+
+
+async def test_run_window_execution_skipped_when_kill_engaged(
+    session_factory: sessionmaker[Session],
+) -> None:
+    """If the kill switch is engaged pre-window, no submissions happen at all."""
+
+    from stockripper.execution.adapter import ExecutionAdapter, MockBrokerClient
+
+    registry = build_registry()
+    with session_factory() as s:
+        repo = Repository(s)
+        repo.engage_kill_switch(reason="ops_drill", engaged_by="test", when=_FROZEN_NOW)
+        s.commit()
+
+    adapter = ExecutionAdapter(
+        session_factory=session_factory,
+        broker=MockBrokerClient(now=_FROZEN_NOW),
+        window_id="opening",
+    )
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced",),
+        symbols=("AAPL",),
+        window_label="opening",
+        config_hash="cfg-kill-exec",
+        now=_FROZEN_NOW,
+        llm_factory=_buying_llm_factory,
+        session_factory=session_factory,
+        execution_adapter=adapter,
+    )
+    assert result.status == "aborted_kill"
+    assert result.submissions == ()
+


### PR DESCRIPTION
Phase 5 implements the universal-floor stack, per-track risk gate, deterministic client_order_id idempotency, and a paper-only execution adapter wired into the Strategy Tracks Manager. Mock and Alpaca paper brokers share the same BrokerClient protocol so unit tests stay offline while `stockripper agents run-window --execute --alpaca` submits real paper orders through alpaca-py.

Highlights:
- risk/floors.py: kill switch, track pause, paper endpoint, schema validity, idempotency, audit completeness. FloorViolation carries a structured FloorCode so the adapter persists a precise rejection rationale on decision_actions.risk_status.
- risk/portfolio.py: lightweight PortfolioState built from track_snapshots, falling back to starting equity.
- risk/gate.py: RiskGate.evaluate honors max_position, max_short, max_options, max_holdings, gross-exposure caps and the leveraged-ETF flag.
- execution/adapter.py: ExecutionAdapter.submit_action runs floors then per-track gate then idempotency lookup then broker submit then persist Order+Fill. MockBrokerClient synthesizes immediate fills at a stable per-symbol pseudo-price. AlpacaPaperBrokerClient calls assert_paper_only at construction.
- window_runner.run_window: new execution_adapter kwarg invokes the adapter for every approved action after persistence. aborted_kill windows skip submission entirely.
- CLI: `stockripper agents run-window --execute [--mock|--alpaca]`.
- db.repository: Phase-5 methods find_order_by_client_order_id, upsert_order (idempotent), list_orders_for_track, set_action_risk_status.

Acceptance per PROJECT_SPEC.md section 25 Phase 5: per-track risk-gate tests pass, paper orders submit automatically through the adapter, duplicates blocked via deterministic client_order_id, kill switch blocks new orders mid-window.

Tests: 32 new (floors 9, gate 11, adapter 9, run_window x execute 3). 237 of 237 green. ruff clean. mypy strict clean.