### PR TITLE
Phase 6: scoring engine + dashboard MVP

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,10 @@ dependencies = [
     "alembic>=1.13",
     "psycopg[binary]>=3.2",
     "alpaca-py>=0.30",
+    "fastapi>=0.136.3",
+    "uvicorn[standard]>=0.48.0",
+    "websockets>=16.0",
+    "httpx-sse>=0.4.3",
 ]
 
 [project.optional-dependencies]
@@ -39,6 +43,7 @@ dev = [
     "ruff>=0.6",
     "mypy>=1.11",
     "types-python-dateutil>=2.9",
+    "httpx>=0.28.1",
 ]
 
 [build-system]

--- a/src/stockripper/__main__.py
+++ b/src/stockripper/__main__.py
@@ -1209,3 +1209,195 @@ def _print_window_result(result: Any) -> None:
         console.print(sub_table)
 
 
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — scoring + dashboard
+# ---------------------------------------------------------------------------
+scoring_app = typer.Typer(
+    help="Score recommendations, compute leaderboards, and compute judge regret.",
+)
+dashboard_app = typer.Typer(help="Live dashboard for orchestrator activity.")
+app.add_typer(scoring_app, name="scoring")
+app.add_typer(dashboard_app, name="dashboard")
+
+
+def _scoring_session_factory(database_url: str | None) -> Any:
+    from sqlalchemy.orm import sessionmaker
+
+    engine = build_engine(database_url)
+    return sessionmaker(engine, expire_on_commit=False, autoflush=False)
+
+
+@scoring_app.command("score")
+def scoring_score(
+    run_id: str = typer.Option(..., "--run-id", help="Window run_id to score."),
+    as_of: str = typer.Option(
+        ..., "--as-of", help="As-of date for the AgentScore rows (ISO YYYY-MM-DD).",
+    ),
+    horizon_days: int = typer.Option(
+        5, "--horizon-days",
+        help="Default horizon used by the stub price provider for tests.",
+    ),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Score every recommendation in ``run_id`` using a stub price provider.
+
+    Live runs should plug in an Alpaca-backed PriceProvider in code;
+    this command intentionally uses the stub so it is safe to invoke
+    offline against any database.
+    """
+
+    from decimal import Decimal
+
+    from stockripper.db.engine import session_scope as _session_scope
+    from stockripper.scoring.reward import (
+        StaticPriceProvider,
+        score_recommendations_for_window,
+    )
+
+    as_of_date = dt.date.fromisoformat(as_of)
+    factory = _scoring_session_factory(database_url)
+    table: dict[tuple[str, dt.date, int], Decimal] = {}
+    with _session_scope(factory) as session:
+        repo = Repository(session)
+        recs = repo.list_recommendations(run_id=run_id)
+        for rec in recs:
+            key = (rec.symbol.upper(), rec.created_at.date(), int(rec.time_horizon_days))
+            table.setdefault(key, Decimal("0"))
+            bench_key = ("SPY", rec.created_at.date(), int(rec.time_horizon_days))
+            table.setdefault(bench_key, Decimal("0"))
+        _ = horizon_days
+        provider = StaticPriceProvider(table=table)
+        rows = score_recommendations_for_window(
+            session=session,
+            run_id=run_id,
+            as_of_date=as_of_date,
+            price_provider=provider,
+        )
+    if not rows:
+        console.print("[yellow]No recommendations scored.[/]")
+        return
+    table_out = Table(title=f"AgentScore rows for run {run_id}")
+    table_out.add_column("agent_id", style="bold cyan")
+    table_out.add_column("track_id")
+    table_out.add_column("reward", justify="right")
+    table_out.add_column("n", justify="right")
+    for agent_id, track_id, reward, n in rows:
+        table_out.add_row(agent_id, track_id, f"{reward:+.6f}", str(n))
+    console.print(table_out)
+
+
+@scoring_app.command("leaderboard")
+def scoring_leaderboard(
+    window_start: str = typer.Option(..., "--window-start"),
+    window_end: str = typer.Option(..., "--window-end"),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Compute and persist the head-to-head per-track leaderboard."""
+
+    from stockripper.db.engine import session_scope as _session_scope
+    from stockripper.scoring.leaderboard import (
+        compute_leaderboard,
+        persist_leaderboard,
+    )
+
+    ws = dt.date.fromisoformat(window_start)
+    we = dt.date.fromisoformat(window_end)
+    factory = _scoring_session_factory(database_url)
+    with _session_scope(factory) as session:
+        metrics = compute_leaderboard(
+            session=session, window_start=ws, window_end=we,
+        )
+        persist_leaderboard(
+            session=session, window_start=ws, window_end=we, metrics=metrics,
+        )
+    if not metrics:
+        console.print("[yellow]No snapshots in window; nothing to rank.[/]")
+        return
+    out = Table(title=f"Track leaderboard {ws} → {we}")
+    out.add_column("track_id", style="bold cyan")
+    out.add_column("cum_ret", justify="right")
+    out.add_column("sharpe", justify="right")
+    out.add_column("max_dd", justify="right")
+    out.add_column("win_rate", justify="right")
+    for m in metrics:
+        out.add_row(
+            m.track_id,
+            "-" if m.cumulative_return_pct is None else f"{m.cumulative_return_pct:+.6f}",
+            "-" if m.sharpe is None else f"{m.sharpe:+.4f}",
+            "-" if m.max_drawdown_pct is None else f"{m.max_drawdown_pct:.6f}",
+            "-" if m.win_rate is None else f"{m.win_rate:.4f}",
+        )
+    console.print(out)
+
+
+@scoring_app.command("regret")
+def scoring_regret(
+    run_id: str = typer.Option(..., "--run-id"),
+    track_id: str = typer.Option(..., "--track-id"),
+    as_of: str = typer.Option(..., "--as-of"),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Compute and persist judge regret for one (run, track, date)."""
+
+    from decimal import Decimal
+
+    from stockripper.db.engine import session_scope as _session_scope
+    from stockripper.scoring.judge_regret import (
+        compute_judge_regret_for_track,
+        persist_judge_regret_for_track,
+    )
+
+    as_of_date = dt.date.fromisoformat(as_of)
+    factory = _scoring_session_factory(database_url)
+    with _session_scope(factory) as session:
+        repo = Repository(session)
+        recs = repo.list_recommendations(run_id=run_id, track_id=track_id)
+        rewards: dict[str, Decimal] = {
+            r.recommendation_id: Decimal("0") for r in recs
+        }
+        report = compute_judge_regret_for_track(
+            session=session,
+            run_id=run_id,
+            track_id=track_id,
+            as_of_date=as_of_date,
+            rewards=rewards,
+        )
+        if report is None:
+            console.print("[yellow]No judge decision or recommendations for that key.[/]")
+            return
+        persist_judge_regret_for_track(session=session, report=report)
+    console.print(
+        f"[bold cyan]Regret[/bold cyan] judge={report.judge_agent_id} "
+        f"track={report.track_id} as_of={report.as_of_date} "
+        f"selected={report.selected_reward:+.6f} "
+        f"best_alt={report.best_alternative_reward:+.6f} "
+        f"regret={report.regret:+.6f} n={report.observation_count}"
+    )
+
+
+@dashboard_app.command("serve")
+def dashboard_serve(
+    host: str = typer.Option("127.0.0.1", "--host"),
+    port: int = typer.Option(8765, "--port"),
+    database_url: str | None = typer.Option(None, "--database-url"),
+) -> None:
+    """Serve the read-only dashboard backed by the ledger DB."""
+
+    import uvicorn
+
+    from stockripper.dashboard.app import build_app
+
+    factory = _scoring_session_factory(database_url)
+    app_instance = build_app(session_factory=factory)
+    console.print(
+        f"[bold green]StockRipper dashboard[/bold green] http://{host}:{port}"
+    )
+    uvicorn.run(app_instance, host=host, port=port, log_level="info")
+
+
+# Repository import is deferred until after the new commands above so that
+# circular-import edge cases stay impossible.
+from stockripper.db.repository import Repository  # noqa: E402
+

--- a/src/stockripper/agents/window_runner.py
+++ b/src/stockripper/agents/window_runner.py
@@ -42,6 +42,12 @@ from stockripper.agents.persistence import (
 )
 from stockripper.agents.registry import AgentRegistry
 from stockripper.agents.schemas import EvidencePacket
+from stockripper.dashboard.events import (
+    DashboardEvent,
+    EventName,
+    NullEventEmitter,
+)
+from stockripper.dashboard.events import EventEmitter as DashboardEmitter
 from stockripper.db.engine import build_session_factory, session_scope
 from stockripper.db.repository import Repository
 from stockripper.execution.adapter import (
@@ -124,6 +130,7 @@ async def run_window(
     session_factory: sessionmaker[Session] | None = None,
     packet_builder: PacketBuilder | None = None,
     execution_adapter: ExecutionAdapter | None = None,
+    event_emitter: DashboardEmitter | None = None,
 ) -> WindowRunResult:
     """Run every enabled (track, symbol) pair in parallel.
 
@@ -166,8 +173,24 @@ async def run_window(
         started_at=when,
     )
 
+    emitter: DashboardEmitter = (
+        event_emitter if event_emitter is not None else NullEventEmitter()
+    )
+
     factory = llm_factory if llm_factory is not None else _default_canned_factory
     pb = packet_builder if packet_builder is not None else _default_packet_builder
+
+    await _safe_emit(
+        emitter,
+        event=EventName.WINDOW_STARTED,
+        run_id=run_id,
+        payload={
+            "window_label": window_label,
+            "trading_day": day.isoformat(),
+            "track_ids": list(track_ids),
+            "symbols": list(symbols),
+        },
+    )
 
     # Pre-flight: open session for control-plane reads + run row creation.
     paused_track_ids: frozenset[str] = frozenset()
@@ -273,6 +296,7 @@ async def run_window(
             window_label=window_label,
             when=when,
             rng_seed=rng_seed,
+            emitter=emitter,
         )
         for w in runnable
     ]
@@ -358,6 +382,35 @@ async def run_window(
             outcomes=all_outcomes,
             adapter=execution_adapter,
         )
+        for sub in submissions:
+            await _safe_emit(
+                emitter,
+                event=EventName.ACTION_SUBMITTED,
+                run_id=run_id,
+                track_id=sub.track_id,
+                symbol=sub.symbol,
+                payload={
+                    "action_id": sub.action_id,
+                    "status": sub.status.value,
+                    "local_order_id": sub.local_order_id,
+                    "client_order_id": sub.client_order_id,
+                    "reason": sub.reason,
+                },
+            )
+
+    await _safe_emit(
+        emitter,
+        event=EventName.WINDOW_COMPLETED,
+        run_id=run_id,
+        payload={
+            "status": final_status,
+            "ok": len([o for o in all_outcomes if o.status == "ok"]),
+            "partial": len([o for o in all_outcomes if o.status == "partial"]),
+            "failed": len([o for o in all_outcomes if o.status == "failed"]),
+            "skipped": len([o for o in all_outcomes if o.status == "skipped_paused"]),
+            "aborted": len([o for o in all_outcomes if o.status == "aborted_kill"]),
+        },
+    )
 
     return WindowRunResult(
         run_id=run_id,
@@ -419,7 +472,17 @@ async def _run_one_track(
     window_label: str,
     when: dt.datetime,
     rng_seed: int | None,
+    emitter: DashboardEmitter | None = None,
 ) -> TrackRunResult:
+    em = emitter if emitter is not None else NullEventEmitter()
+    await _safe_emit(
+        em,
+        event=EventName.TRACK_STARTED,
+        run_id=run_id,
+        track_id=item.track_id,
+        symbol=item.symbol,
+        payload={"packet_id": item.packet_id, "track_run_id": item.track_run_id},
+    )
     packet = packet_builder(
         symbol=item.symbol,
         track_id=item.track_id,
@@ -428,7 +491,7 @@ async def _run_one_track(
         now=when,
     )
     llm = llm_factory(packet)
-    return await run_track(
+    result = await run_track(
         registry=registry,
         track_id=item.track_id,
         packet=packet,
@@ -438,6 +501,96 @@ async def _run_one_track(
         window_run_id=run_id,
         now=when,
     )
+    for run in result.all_runs:
+        await _safe_emit(
+            em,
+            event=EventName.AGENT_COMPLETED,
+            run_id=run_id,
+            track_id=item.track_id,
+            agent_id=run.agent_id,
+            symbol=item.symbol,
+            payload={"status": run.status.value, "agent_run_id": run.run_id},
+        )
+    for council_run in result.council_runs:
+        out = council_run.output
+        if out is None:
+            continue
+        await _safe_emit(
+            em,
+            event=EventName.RECOMMENDATION_EMITTED,
+            run_id=run_id,
+            track_id=item.track_id,
+            agent_id=council_run.agent_id,
+            symbol=getattr(out, "symbol", item.symbol),
+            payload={
+                "action": getattr(out, "action", None),
+                "conviction": str(getattr(out, "conviction", "")),
+                "thesis": getattr(out, "thesis", None),
+            },
+        )
+    if result.judge_run is not None and result.judge_run.output is not None:
+        decision = result.judge_run.output
+        plan = getattr(decision, "plan", None)
+        await _safe_emit(
+            em,
+            event=EventName.JUDGE_DECIDED,
+            run_id=run_id,
+            track_id=item.track_id,
+            agent_id=result.judge_run.agent_id,
+            symbol=item.symbol,
+            payload={
+                "posture": (
+                    str(plan.portfolio_posture)
+                    if plan is not None and plan.portfolio_posture is not None
+                    else None
+                ),
+                "actions": (
+                    len(plan.items) if plan is not None else 0
+                ),
+                "objective": (
+                    plan.objective_label if plan is not None else None
+                ),
+            },
+        )
+    await _safe_emit(
+        em,
+        event=EventName.TRACK_COMPLETED,
+        run_id=run_id,
+        track_id=item.track_id,
+        symbol=item.symbol,
+        payload={"track_run_id": item.track_run_id},
+    )
+    return result
+
+
+async def _safe_emit(
+    emitter: DashboardEmitter,
+    *,
+    event: EventName,
+    run_id: str | None = None,
+    track_id: str | None = None,
+    agent_id: str | None = None,
+    symbol: str | None = None,
+    payload: dict[str, object] | None = None,
+) -> None:
+    """Publish a :class:`DashboardEvent` swallowing all errors.
+
+    Event publication must never break the orchestrator hot path.
+    """
+
+    try:
+        await emitter.publish(
+            DashboardEvent(
+                event=event,
+                run_id=run_id,
+                track_id=track_id,
+                agent_id=agent_id,
+                symbol=symbol,
+                payload=payload or {},
+            ),
+        )
+    except Exception:  # defensive — emission must never break run_window
+        LOG.debug("Dashboard event emission failed for %s", event, exc_info=True)
 
 
 def _aggregate_status(

--- a/src/stockripper/alembic/versions/20260530_phase6_scoring.py
+++ b/src/stockripper/alembic/versions/20260530_phase6_scoring.py
@@ -1,0 +1,98 @@
+"""phase 6 scoring tables
+
+Revision ID: 20260530_phase6_scoring
+Revises: 20260528_phase4_orchestrator
+Create Date: 2026-05-30 00:00:00.000000
+
+Adds the three tables Phase-6 scoring needs:
+
+* ``agent_scores`` — per-(agent, track, date) reward / calibration / shadow.
+* ``track_leaderboard`` — head-to-head per-window track ranking.
+* ``judge_regret`` — per-judge regret summary per (track, date).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260530_phase6_scoring"
+down_revision: str | None | Sequence[str] = "20260528_phase4_orchestrator"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "agent_scores",
+        sa.Column("score_id", sa.String(64), primary_key=True),
+        sa.Column("agent_id", sa.String(64), nullable=False),
+        sa.Column(
+            "track_id", sa.String(64),
+            sa.ForeignKey("strategy_tracks.track_id"), nullable=False,
+        ),
+        sa.Column("as_of_date", sa.Date(), nullable=False),
+        sa.Column("reward_score", sa.Numeric(18, 6), nullable=False),
+        sa.Column("calibration_score", sa.Numeric(18, 6), nullable=True),
+        sa.Column("evidence_quality_score", sa.Numeric(18, 6), nullable=True),
+        sa.Column("shadow_return_pct", sa.Numeric(10, 6), nullable=True),
+        sa.Column("selected_return_pct", sa.Numeric(10, 6), nullable=True),
+        sa.Column("observation_count", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "agent_id", "track_id", "as_of_date",
+            name="uq_agent_scores_agent_track_date",
+        ),
+    )
+
+    op.create_table(
+        "track_leaderboard",
+        sa.Column("leaderboard_id", sa.String(64), primary_key=True),
+        sa.Column("window_start", sa.Date(), nullable=False),
+        sa.Column("window_end", sa.Date(), nullable=False),
+        sa.Column(
+            "track_id", sa.String(64),
+            sa.ForeignKey("strategy_tracks.track_id"), nullable=False,
+        ),
+        sa.Column("cumulative_return_pct", sa.Numeric(10, 6), nullable=True),
+        sa.Column("sharpe", sa.Numeric(10, 6), nullable=True),
+        sa.Column("sortino", sa.Numeric(10, 6), nullable=True),
+        sa.Column("calmar", sa.Numeric(10, 6), nullable=True),
+        sa.Column("max_drawdown_pct", sa.Numeric(10, 6), nullable=True),
+        sa.Column("win_rate", sa.Numeric(10, 6), nullable=True),
+        sa.Column("turnover", sa.Numeric(10, 6), nullable=True),
+        sa.Column("rank", sa.Integer(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "window_start", "window_end", "track_id",
+            name="uq_track_leaderboard_window_track",
+        ),
+    )
+
+    op.create_table(
+        "judge_regret",
+        sa.Column("regret_id", sa.String(64), primary_key=True),
+        sa.Column("judge_agent_id", sa.String(64), nullable=False),
+        sa.Column(
+            "track_id", sa.String(64),
+            sa.ForeignKey("strategy_tracks.track_id"), nullable=False,
+        ),
+        sa.Column("as_of_date", sa.Date(), nullable=False),
+        sa.Column("selected_reward", sa.Numeric(18, 6), nullable=False),
+        sa.Column("best_alternative_reward", sa.Numeric(18, 6), nullable=False),
+        sa.Column("regret", sa.Numeric(18, 6), nullable=False),
+        sa.Column("observation_count", sa.Integer(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.UniqueConstraint(
+            "judge_agent_id", "track_id", "as_of_date",
+            name="uq_judge_regret_judge_track_date",
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("judge_regret")
+    op.drop_table("track_leaderboard")
+    op.drop_table("agent_scores")

--- a/src/stockripper/dashboard/__init__.py
+++ b/src/stockripper/dashboard/__init__.py
@@ -1,0 +1,33 @@
+"""StockRipper dashboard MVP (spec §19 / §25 Phase 6).
+
+Provides:
+
+* :class:`stockripper.dashboard.events.EventBus` — async pub-sub used
+  by the orchestrator to publish per-window structured events.
+* :func:`stockripper.dashboard.app.build_app` — FastAPI app factory
+  with REST endpoints for runs, tracks, leaderboard, agent scores,
+  judge regret, and a WebSocket ``/ws/events`` stream.
+* ``stockripper.dashboard.static`` — minimal vanilla-JS SPA served at
+  ``/``.
+
+The dashboard is read-only against the ledger; the orchestrator
+optionally publishes events into it via :class:`EventBus`.
+"""
+
+from __future__ import annotations
+
+from stockripper.dashboard.app import build_app
+from stockripper.dashboard.events import (
+    DashboardEvent,
+    EventBus,
+    EventName,
+    NullEventEmitter,
+)
+
+__all__ = (
+    "DashboardEvent",
+    "EventBus",
+    "EventName",
+    "NullEventEmitter",
+    "build_app",
+)

--- a/src/stockripper/dashboard/app.py
+++ b/src/stockripper/dashboard/app.py
@@ -1,0 +1,277 @@
+"""FastAPI dashboard app (spec §19)."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+import json
+from collections.abc import Callable, Iterable
+from contextlib import asynccontextmanager
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from fastapi import FastAPI, HTTPException, Query, WebSocket, WebSocketDisconnect
+from fastapi.responses import JSONResponse
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.dashboard.events import EventBus
+from stockripper.db.repository import Repository
+
+SessionFactory = Callable[[], Session]
+
+
+def _to_jsonable(value: Any) -> Any:
+    if isinstance(value, Decimal):
+        return str(value)
+    if isinstance(value, (dt.datetime, dt.date)):
+        return value.isoformat()
+    return value
+
+
+def _serialize_run(run: Any) -> dict[str, Any]:
+    return {
+        "run_id": run.run_id,
+        "experiment_id": run.experiment_id,
+        "trading_day": _to_jsonable(run.trading_day),
+        "window_label": run.window_label,
+        "status": run.status,
+        "started_at": _to_jsonable(run.started_at),
+        "completed_at": _to_jsonable(run.completed_at),
+        "config_hash": run.config_hash,
+        "notes": run.notes,
+    }
+
+
+def _serialize_track(track: Any) -> dict[str, Any]:
+    return {
+        "track_id": track.track_id,
+        "name": track.name,
+        "philosophy": track.philosophy,
+        "risk_policy_id": track.risk_policy_id,
+        "judge_objective": track.judge_objective,
+        "enabled": track.enabled,
+        "starting_equity_usd": _to_jsonable(track.starting_equity_usd),
+    }
+
+
+def _serialize_recommendation(rec: Any) -> dict[str, Any]:
+    return {
+        "recommendation_id": rec.recommendation_id,
+        "run_id": rec.run_id,
+        "track_id": rec.track_id,
+        "agent_id": rec.agent_id,
+        "symbol": rec.symbol,
+        "instrument_type": rec.instrument_type,
+        "action": rec.action,
+        "conviction": _to_jsonable(rec.conviction),
+        "time_horizon_days": rec.time_horizon_days,
+        "expected_return_pct": _to_jsonable(rec.expected_return_pct),
+        "thesis": rec.thesis,
+        "created_at": _to_jsonable(rec.created_at),
+    }
+
+
+def _serialize_leaderboard_entry(row: Any) -> dict[str, Any]:
+    return {
+        "leaderboard_id": row.leaderboard_id,
+        "window_start": _to_jsonable(row.window_start),
+        "window_end": _to_jsonable(row.window_end),
+        "track_id": row.track_id,
+        "cumulative_return_pct": _to_jsonable(row.cumulative_return_pct),
+        "sharpe": _to_jsonable(row.sharpe),
+        "sortino": _to_jsonable(row.sortino),
+        "calmar": _to_jsonable(row.calmar),
+        "max_drawdown_pct": _to_jsonable(row.max_drawdown_pct),
+        "win_rate": _to_jsonable(row.win_rate),
+        "turnover": _to_jsonable(row.turnover),
+        "rank": row.rank,
+    }
+
+
+def _serialize_agent_score(row: Any) -> dict[str, Any]:
+    return {
+        "score_id": row.score_id,
+        "agent_id": row.agent_id,
+        "track_id": row.track_id,
+        "as_of_date": _to_jsonable(row.as_of_date),
+        "reward_score": _to_jsonable(row.reward_score),
+        "selected_return_pct": _to_jsonable(row.selected_return_pct),
+        "shadow_return_pct": _to_jsonable(row.shadow_return_pct),
+        "observation_count": row.observation_count,
+    }
+
+
+def _serialize_judge_regret(row: Any) -> dict[str, Any]:
+    return {
+        "regret_id": row.regret_id,
+        "judge_agent_id": row.judge_agent_id,
+        "track_id": row.track_id,
+        "as_of_date": _to_jsonable(row.as_of_date),
+        "selected_reward": _to_jsonable(row.selected_reward),
+        "best_alternative_reward": _to_jsonable(row.best_alternative_reward),
+        "regret": _to_jsonable(row.regret),
+        "observation_count": row.observation_count,
+    }
+
+
+def _parse_date(value: str | None) -> dt.date | None:
+    if value is None:
+        return None
+    try:
+        return dt.date.fromisoformat(value)
+    except ValueError as exc:
+        raise HTTPException(
+            status_code=400, detail=f"Invalid date: {value!r}",
+        ) from exc
+
+
+def _static_dir() -> Path:
+    return Path(__file__).resolve().parent / "static"
+
+
+def build_app(
+    *,
+    session_factory: SessionFactory | sessionmaker[Session],
+    event_bus: EventBus | None = None,
+) -> FastAPI:
+    """Construct a FastAPI dashboard app.
+
+    ``session_factory`` may be a vanilla callable returning a Session or
+    a SQLAlchemy ``sessionmaker``; both are callable with no args.
+    """
+
+    bus = event_bus or EventBus()
+
+    @asynccontextmanager
+    async def lifespan(_app: FastAPI) -> Any:
+        try:
+            yield
+        finally:
+            await bus.close()
+
+    app = FastAPI(
+        title="StockRipper Dashboard",
+        version="0.6.0",
+        lifespan=lifespan,
+    )
+
+    def _open_session() -> Session:
+        return session_factory()
+
+    @app.get("/api/health")
+    def health() -> dict[str, Any]:
+        return {"status": "ok", "subscribers": bus.subscriber_count}
+
+    @app.get("/api/runs")
+    def list_runs(limit: int = Query(default=50, ge=1, le=500)) -> JSONResponse:
+        with _open_session() as session:
+            repo = Repository(session)
+            runs = repo.list_runs(limit=limit)
+            return JSONResponse([_serialize_run(r) for r in runs])
+
+    @app.get("/api/runs/{run_id}")
+    def get_run(run_id: str) -> JSONResponse:
+        with _open_session() as session:
+            repo = Repository(session)
+            run = repo.get_run(run_id)
+            if run is None:
+                raise HTTPException(status_code=404, detail="run not found")
+            recs = repo.list_recommendations(run_id=run_id)
+            return JSONResponse(
+                {
+                    "run": _serialize_run(run),
+                    "recommendations": [
+                        _serialize_recommendation(r) for r in recs
+                    ],
+                },
+            )
+
+    @app.get("/api/tracks")
+    def list_tracks() -> JSONResponse:
+        with _open_session() as session:
+            repo = Repository(session)
+            tracks = repo.list_strategy_tracks()
+            return JSONResponse([_serialize_track(t) for t in tracks])
+
+    @app.get("/api/leaderboard")
+    def leaderboard(
+        window_start: str | None = Query(default=None),
+        window_end: str | None = Query(default=None),
+    ) -> JSONResponse:
+        ws = _parse_date(window_start)
+        we = _parse_date(window_end)
+        with _open_session() as session:
+            repo = Repository(session)
+            rows = repo.list_leaderboard(window_start=ws, window_end=we)
+            return JSONResponse(
+                [_serialize_leaderboard_entry(r) for r in rows],
+            )
+
+    @app.get("/api/agent-scores")
+    def agent_scores(
+        track_id: str | None = Query(default=None),
+        agent_id: str | None = Query(default=None),
+        as_of_date: str | None = Query(default=None),
+    ) -> JSONResponse:
+        with _open_session() as session:
+            repo = Repository(session)
+            rows = repo.list_agent_scores(
+                track_id=track_id,
+                agent_id=agent_id,
+                as_of_date=_parse_date(as_of_date),
+            )
+            return JSONResponse(
+                [_serialize_agent_score(r) for r in rows],
+            )
+
+    @app.get("/api/judge-regret")
+    def judge_regret(
+        track_id: str | None = Query(default=None),
+    ) -> JSONResponse:
+        with _open_session() as session:
+            repo = Repository(session)
+            rows = repo.list_judge_regret(track_id=track_id)
+            return JSONResponse(
+                [_serialize_judge_regret(r) for r in rows],
+            )
+
+    @app.websocket("/ws/events")
+    async def ws_events(websocket: WebSocket) -> None:
+        await websocket.accept()
+        try:
+            async for event in bus.subscribe():
+                await websocket.send_text(
+                    event.model_dump_json(),
+                )
+        except WebSocketDisconnect:
+            return
+        except asyncio.CancelledError:  # pragma: no cover — shutdown
+            return
+
+    # Mount static SPA last so /api/* routes win.
+    static_dir = _static_dir()
+    if static_dir.exists():
+        app.mount(
+            "/", StaticFiles(directory=str(static_dir), html=True), name="ui",
+        )
+
+    return app
+
+
+def app_event_bus(app: FastAPI) -> EventBus | None:
+    """Walk app dependencies to find the wired :class:`EventBus`."""
+
+    # FastAPI doesn't expose the lifespan-bound closures; consumers
+    # should pass the EventBus into build_app rather than fishing for it
+    # here. Kept as a hook for future introspection tooling.
+    _ = app
+    return None
+
+
+def _serialize_iter(rows: Iterable[Any]) -> str:
+    return json.dumps([_to_jsonable(r) for r in rows], default=str)
+
+
+__all__ = ("build_app",)

--- a/src/stockripper/dashboard/events.py
+++ b/src/stockripper/dashboard/events.py
@@ -1,0 +1,119 @@
+"""Async pub-sub event bus for dashboard live feed (spec §19.2)."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import datetime as dt
+from collections.abc import AsyncIterator
+from enum import StrEnum
+from typing import Any, Final, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class EventName(StrEnum):
+    WINDOW_STARTED = "window_started"
+    TRACK_STARTED = "track_started"
+    AGENT_COMPLETED = "agent_completed"
+    RECOMMENDATION_EMITTED = "recommendation_emitted"
+    JUDGE_DECIDED = "judge_decided"
+    ACTION_SUBMITTED = "action_submitted"
+    TRACK_COMPLETED = "track_completed"
+    WINDOW_COMPLETED = "window_completed"
+    KILL_SWITCH_CHANGED = "kill_switch_changed"
+    TRACK_PAUSE_CHANGED = "track_pause_changed"
+
+
+class DashboardEvent(BaseModel):
+    """One structured event emitted into the live dashboard feed."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    event: EventName
+    run_id: str | None = None
+    track_id: str | None = None
+    agent_id: str | None = None
+    symbol: str | None = None
+    payload: dict[str, Any] = Field(default_factory=dict)
+    emitted_at: dt.datetime = Field(default_factory=lambda: dt.datetime.now(dt.UTC))
+
+
+class EventEmitter(Protocol):
+    """Anything that can accept dashboard events (real bus or no-op)."""
+
+    async def publish(self, event: DashboardEvent) -> None: ...
+
+
+class NullEventEmitter:
+    """No-op emitter used when the dashboard is not attached."""
+
+    async def publish(self, event: DashboardEvent) -> None:
+        return None
+
+
+_DEFAULT_QUEUE_SIZE: Final[int] = 1024
+
+
+class EventBus:
+    """Fan-out async event bus.
+
+    ``publish`` is non-blocking (drops the oldest item on a full queue
+    to keep the orchestrator path latency-bounded); ``subscribe``
+    returns an :class:`AsyncIterator` that yields events until the bus
+    is closed.
+    """
+
+    def __init__(self, *, queue_size: int = _DEFAULT_QUEUE_SIZE) -> None:
+        self._queue_size = queue_size
+        self._subscribers: list[asyncio.Queue[DashboardEvent]] = []
+        self._lock = asyncio.Lock()
+        self._closed = False
+
+    async def publish(self, event: DashboardEvent) -> None:
+        if self._closed:
+            return
+        async with self._lock:
+            subscribers = list(self._subscribers)
+        for queue in subscribers:
+            if queue.full():
+                with contextlib.suppress(asyncio.QueueEmpty):
+                    queue.get_nowait()
+            try:
+                queue.put_nowait(event)
+            except asyncio.QueueFull:  # pragma: no cover — defensive
+                continue
+
+    async def subscribe(self) -> AsyncIterator[DashboardEvent]:
+        queue: asyncio.Queue[DashboardEvent] = asyncio.Queue(self._queue_size)
+        async with self._lock:
+            self._subscribers.append(queue)
+        try:
+            while True:
+                event = await queue.get()
+                if event.event == EventName.WINDOW_COMPLETED and self._closed:
+                    yield event
+                    return
+                yield event
+        finally:
+            async with self._lock:
+                if queue in self._subscribers:
+                    self._subscribers.remove(queue)
+
+    async def close(self) -> None:
+        self._closed = True
+        async with self._lock:
+            self._subscribers.clear()
+
+    @property
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)
+
+
+__all__ = (
+    "DashboardEvent",
+    "EventBus",
+    "EventEmitter",
+    "EventName",
+    "NullEventEmitter",
+)

--- a/src/stockripper/dashboard/static/index.html
+++ b/src/stockripper/dashboard/static/index.html
@@ -1,0 +1,209 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>StockRipper Dashboard</title>
+  <style>
+    :root {
+      color-scheme: dark;
+      --bg: #0d1117;
+      --panel: #161b22;
+      --border: #30363d;
+      --text: #e6edf3;
+      --muted: #8b949e;
+      --accent: #58a6ff;
+      --good: #3fb950;
+      --bad: #f85149;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      font-size: 14px;
+    }
+    header {
+      padding: 12px 20px;
+      border-bottom: 1px solid var(--border);
+      display: flex;
+      align-items: baseline;
+      justify-content: space-between;
+    }
+    header h1 { margin: 0; font-size: 18px; font-weight: 600; }
+    header .status { color: var(--muted); font-size: 12px; }
+    header .status .dot {
+      display: inline-block; width: 8px; height: 8px; border-radius: 50%;
+      background: var(--bad); margin-right: 6px; vertical-align: middle;
+    }
+    header .status.connected .dot { background: var(--good); }
+    main {
+      display: grid;
+      grid-template-columns: 1fr 1fr;
+      grid-template-rows: minmax(280px, 1fr) minmax(280px, 1fr);
+      gap: 12px;
+      padding: 12px;
+      height: calc(100vh - 49px);
+    }
+    section {
+      background: var(--panel);
+      border: 1px solid var(--border);
+      border-radius: 8px;
+      padding: 12px;
+      overflow: auto;
+    }
+    section h2 {
+      margin: 0 0 8px;
+      font-size: 13px;
+      font-weight: 600;
+      color: var(--muted);
+      text-transform: uppercase;
+      letter-spacing: 0.04em;
+    }
+    table { width: 100%; border-collapse: collapse; }
+    th, td {
+      text-align: left;
+      padding: 6px 8px;
+      border-bottom: 1px solid var(--border);
+      font-variant-numeric: tabular-nums;
+    }
+    th { color: var(--muted); font-weight: 500; font-size: 12px; }
+    td.num { text-align: right; }
+    td .pos { color: var(--good); }
+    td .neg { color: var(--bad); }
+    .feed-item {
+      border-bottom: 1px solid var(--border);
+      padding: 6px 0;
+      font-family: ui-monospace, Menlo, monospace;
+      font-size: 12px;
+    }
+    .feed-item .ts { color: var(--muted); margin-right: 6px; }
+    .feed-item .ev { color: var(--accent); margin-right: 6px; }
+    .empty { color: var(--muted); padding: 16px; text-align: center; }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>StockRipper · Council Live View</h1>
+    <div id="status" class="status"><span class="dot"></span><span id="status-text">connecting…</span></div>
+  </header>
+  <main>
+    <section>
+      <h2>Live Council Feed</h2>
+      <div id="feed"><div class="empty">Waiting for events…</div></div>
+    </section>
+    <section>
+      <h2>Recent Runs</h2>
+      <div id="runs"><div class="empty">Loading…</div></div>
+    </section>
+    <section>
+      <h2>Track Leaderboard</h2>
+      <div id="leaderboard"><div class="empty">Loading…</div></div>
+    </section>
+    <section>
+      <h2>Top Agent Scores</h2>
+      <div id="scores"><div class="empty">Loading…</div></div>
+    </section>
+  </main>
+  <script>
+    const $ = (id) => document.getElementById(id);
+    const fmtPct = (v) => v === null || v === undefined ? "—" : (Number(v) * 100).toFixed(2) + "%";
+    const fmtNum = (v) => v === null || v === undefined ? "—" : Number(v).toFixed(3);
+    const sign = (v) => v === null || v === undefined ? "" : (Number(v) >= 0 ? "pos" : "neg");
+
+    async function refreshRuns() {
+      const r = await fetch("/api/runs?limit=10");
+      if (!r.ok) return;
+      const rows = await r.json();
+      if (!rows.length) {
+        $("runs").innerHTML = '<div class="empty">No runs yet.</div>';
+        return;
+      }
+      $("runs").innerHTML = `<table><thead><tr>
+        <th>Run</th><th>Day</th><th>Window</th><th>Status</th><th>Started</th>
+      </tr></thead><tbody>${rows.map(r => `<tr>
+        <td>${r.run_id.slice(0,16)}…</td>
+        <td>${r.trading_day || "—"}</td>
+        <td>${r.window_label || "—"}</td>
+        <td>${r.status}</td>
+        <td>${r.started_at || "—"}</td>
+      </tr>`).join("")}</tbody></table>`;
+    }
+    async function refreshLeaderboard() {
+      const r = await fetch("/api/leaderboard");
+      if (!r.ok) return;
+      const rows = await r.json();
+      if (!rows.length) {
+        $("leaderboard").innerHTML = '<div class="empty">No leaderboard data.</div>';
+        return;
+      }
+      $("leaderboard").innerHTML = `<table><thead><tr>
+        <th>Rank</th><th>Track</th><th>Cum Return</th><th>Sharpe</th><th>Max DD</th><th>Win Rate</th>
+      </tr></thead><tbody>${rows.map(r => `<tr>
+        <td>${r.rank || "—"}</td>
+        <td>${r.track_id}</td>
+        <td class="num"><span class="${sign(r.cumulative_return_pct)}">${fmtPct(r.cumulative_return_pct)}</span></td>
+        <td class="num">${fmtNum(r.sharpe)}</td>
+        <td class="num">${fmtPct(r.max_drawdown_pct)}</td>
+        <td class="num">${fmtPct(r.win_rate)}</td>
+      </tr>`).join("")}</tbody></table>`;
+    }
+    async function refreshScores() {
+      const r = await fetch("/api/agent-scores");
+      if (!r.ok) return;
+      const rows = (await r.json()).slice(0, 20);
+      if (!rows.length) {
+        $("scores").innerHTML = '<div class="empty">No scored agents yet.</div>';
+        return;
+      }
+      $("scores").innerHTML = `<table><thead><tr>
+        <th>Agent</th><th>Track</th><th>Date</th><th>Reward</th><th>N</th>
+      </tr></thead><tbody>${rows.map(r => `<tr>
+        <td>${r.agent_id}</td>
+        <td>${r.track_id}</td>
+        <td>${r.as_of_date}</td>
+        <td class="num"><span class="${sign(r.reward_score)}">${fmtPct(r.reward_score)}</span></td>
+        <td class="num">${r.observation_count}</td>
+      </tr>`).join("")}</tbody></table>`;
+    }
+    function setStatus(connected) {
+      $("status").classList.toggle("connected", connected);
+      $("status-text").textContent = connected ? "live" : "disconnected";
+    }
+    function feedItem(evt) {
+      const el = document.createElement("div");
+      el.className = "feed-item";
+      const ts = (evt.emitted_at || "").replace("T", " ").split(".")[0];
+      const label = evt.event;
+      const ctx = [evt.track_id, evt.symbol, evt.agent_id].filter(Boolean).join(" · ");
+      el.innerHTML = `<span class="ts">${ts}</span><span class="ev">${label}</span>${ctx}`;
+      return el;
+    }
+    function connect() {
+      const proto = location.protocol === "https:" ? "wss:" : "ws:";
+      const ws = new WebSocket(`${proto}//${location.host}/ws/events`);
+      ws.onopen = () => setStatus(true);
+      ws.onclose = () => { setStatus(false); setTimeout(connect, 1500); };
+      ws.onerror = () => ws.close();
+      ws.onmessage = (m) => {
+        try {
+          const evt = JSON.parse(m.data);
+          const feed = $("feed");
+          if (feed.firstElementChild && feed.firstElementChild.classList.contains("empty")) {
+            feed.innerHTML = "";
+          }
+          feed.insertBefore(feedItem(evt), feed.firstChild);
+          while (feed.children.length > 200) feed.removeChild(feed.lastChild);
+          if (["track_completed", "window_completed"].includes(evt.event)) {
+            refreshRuns(); refreshLeaderboard(); refreshScores();
+          }
+        } catch (e) { /* ignore malformed */ }
+      };
+    }
+    refreshRuns(); refreshLeaderboard(); refreshScores();
+    setInterval(() => { refreshRuns(); refreshLeaderboard(); refreshScores(); }, 15000);
+    connect();
+  </script>
+</body>
+</html>

--- a/src/stockripper/db/__init__.py
+++ b/src/stockripper/db/__init__.py
@@ -3,16 +3,19 @@
 from stockripper.db.engine import build_engine, build_session_factory, session_scope
 from stockripper.db.models import (
     AgentRun,
+    AgentScore,
     Base,
     DecisionAction,
     Fill,
     JudgeDecision,
+    JudgeRegretEntry,
     KillSwitchState,
     Order,
     Recommendation,
     RiskPolicy,
     Run,
     StrategyTrack,
+    TrackLeaderboardEntry,
     TrackPauseState,
     TrackRun,
     TrackSnapshot,
@@ -21,10 +24,12 @@ from stockripper.db.repository import Repository
 
 __all__ = (
     "AgentRun",
+    "AgentScore",
     "Base",
     "DecisionAction",
     "Fill",
     "JudgeDecision",
+    "JudgeRegretEntry",
     "KillSwitchState",
     "Order",
     "Recommendation",
@@ -32,6 +37,7 @@ __all__ = (
     "RiskPolicy",
     "Run",
     "StrategyTrack",
+    "TrackLeaderboardEntry",
     "TrackPauseState",
     "TrackRun",
     "TrackSnapshot",
@@ -39,3 +45,4 @@ __all__ = (
     "build_session_factory",
     "session_scope",
 )
+

--- a/src/stockripper/db/models.py
+++ b/src/stockripper/db/models.py
@@ -406,3 +406,121 @@ class TrackPauseState(Base):
     updated_at: Mapped[dt.datetime] = mapped_column(
         DateTime(timezone=True), nullable=False, default=_utcnow,
     )
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — scoring tables (spec §15.2)
+# ---------------------------------------------------------------------------
+class AgentScore(Base):
+    """One reward observation for an (agent, track, as_of_date) triple.
+
+    Reward signal is derived per-recommendation from the realized symbol
+    price move over the recommendation's nominal horizon vs the SPY
+    benchmark over the same horizon. Multiple recommendations from the
+    same agent on the same day collapse into one row keyed by
+    ``(agent_id, track_id, as_of_date)`` so the dashboard can render a
+    stable per-agent leaderboard.
+    """
+
+    __tablename__ = "agent_scores"
+    __table_args__ = (
+        UniqueConstraint(
+            "agent_id", "track_id", "as_of_date",
+            name="uq_agent_scores_agent_track_date",
+        ),
+    )
+
+    score_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    track_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("strategy_tracks.track_id"), nullable=False,
+    )
+    as_of_date: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    reward_score: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    calibration_score: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6), nullable=True,
+    )
+    evidence_quality_score: Mapped[Decimal | None] = mapped_column(
+        Numeric(18, 6), nullable=True,
+    )
+    shadow_return_pct: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 6), nullable=True,
+    )
+    selected_return_pct: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 6), nullable=True,
+    )
+    observation_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )
+
+
+class TrackLeaderboardEntry(Base):
+    """One row in the head-to-head track leaderboard for one window."""
+
+    __tablename__ = "track_leaderboard"
+    __table_args__ = (
+        UniqueConstraint(
+            "window_start", "window_end", "track_id",
+            name="uq_track_leaderboard_window_track",
+        ),
+    )
+
+    leaderboard_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    window_start: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    window_end: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    track_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("strategy_tracks.track_id"), nullable=False,
+    )
+    cumulative_return_pct: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 6), nullable=True,
+    )
+    sharpe: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    sortino: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    calmar: Mapped[Decimal | None] = mapped_column(Numeric(10, 6), nullable=True)
+    max_drawdown_pct: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 6), nullable=True,
+    )
+    win_rate: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 6), nullable=True,
+    )
+    turnover: Mapped[Decimal | None] = mapped_column(
+        Numeric(10, 6), nullable=True,
+    )
+    rank: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )
+
+
+class JudgeRegretEntry(Base):
+    """Per-(judge, track, as_of_date) regret record.
+
+    Compares the judge's actual selected actions (and their realized
+    reward) against the best-counterfactual judge over the same
+    recommendation set. Drives the spec §8.3 / §19.4 judge leaderboard.
+    """
+
+    __tablename__ = "judge_regret"
+    __table_args__ = (
+        UniqueConstraint(
+            "judge_agent_id", "track_id", "as_of_date",
+            name="uq_judge_regret_judge_track_date",
+        ),
+    )
+
+    regret_id: Mapped[str] = mapped_column(String(64), primary_key=True)
+    judge_agent_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    track_id: Mapped[str] = mapped_column(
+        String(64), ForeignKey("strategy_tracks.track_id"), nullable=False,
+    )
+    as_of_date: Mapped[dt.date] = mapped_column(Date, nullable=False)
+    selected_reward: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    best_alternative_reward: Mapped[Decimal] = mapped_column(
+        Numeric(18, 6), nullable=False,
+    )
+    regret: Mapped[Decimal] = mapped_column(Numeric(18, 6), nullable=False)
+    observation_count: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[dt.datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, default=_utcnow,
+    )

--- a/src/stockripper/db/repository.py
+++ b/src/stockripper/db/repository.py
@@ -17,15 +17,18 @@ from sqlalchemy.orm import Session
 
 from stockripper.db.models import (
     AgentRun,
+    AgentScore,
     DecisionAction,
     Fill,
     JudgeDecision,
+    JudgeRegretEntry,
     KillSwitchState,
     Order,
     Recommendation,
     RiskPolicy,
     Run,
     StrategyTrack,
+    TrackLeaderboardEntry,
     TrackPauseState,
     TrackRun,
     TrackSnapshot,
@@ -624,6 +627,194 @@ class Repository:
 
     def list_track_pause_states(self) -> list[TrackPauseState]:
         stmt = select(TrackPauseState).order_by(TrackPauseState.track_id)
+        return list(self.session.execute(stmt).scalars())
+
+    # ------------------------------------------------------------------
+    # Phase 6 — scoring (agent_scores, track_leaderboard, judge_regret)
+    # ------------------------------------------------------------------
+    def upsert_agent_score(
+        self,
+        *,
+        score_id: str,
+        agent_id: str,
+        track_id: str,
+        as_of_date: dt.date,
+        reward_score: Decimal,
+        observation_count: int,
+        calibration_score: Decimal | None = None,
+        evidence_quality_score: Decimal | None = None,
+        shadow_return_pct: Decimal | None = None,
+        selected_return_pct: Decimal | None = None,
+    ) -> AgentScore:
+        existing = self.session.get(AgentScore, score_id)
+        if existing is not None:
+            existing.reward_score = reward_score
+            existing.calibration_score = calibration_score
+            existing.evidence_quality_score = evidence_quality_score
+            existing.shadow_return_pct = shadow_return_pct
+            existing.selected_return_pct = selected_return_pct
+            existing.observation_count = observation_count
+            self.session.flush()
+            return existing
+        row = AgentScore(
+            score_id=score_id,
+            agent_id=agent_id,
+            track_id=track_id,
+            as_of_date=as_of_date,
+            reward_score=reward_score,
+            calibration_score=calibration_score,
+            evidence_quality_score=evidence_quality_score,
+            shadow_return_pct=shadow_return_pct,
+            selected_return_pct=selected_return_pct,
+            observation_count=observation_count,
+        )
+        self.session.add(row)
+        self.session.flush()
+        return row
+
+    def list_agent_scores(
+        self, *, track_id: str | None = None,
+        agent_id: str | None = None,
+        as_of_date: dt.date | None = None,
+    ) -> list[AgentScore]:
+        stmt = select(AgentScore)
+        if track_id is not None:
+            stmt = stmt.where(AgentScore.track_id == track_id)
+        if agent_id is not None:
+            stmt = stmt.where(AgentScore.agent_id == agent_id)
+        if as_of_date is not None:
+            stmt = stmt.where(AgentScore.as_of_date == as_of_date)
+        stmt = stmt.order_by(
+            AgentScore.as_of_date.desc(),
+            AgentScore.reward_score.desc(),
+        )
+        return list(self.session.execute(stmt).scalars())
+
+    def upsert_leaderboard_entry(
+        self,
+        *,
+        leaderboard_id: str,
+        window_start: dt.date,
+        window_end: dt.date,
+        track_id: str,
+        cumulative_return_pct: Decimal | None = None,
+        sharpe: Decimal | None = None,
+        sortino: Decimal | None = None,
+        calmar: Decimal | None = None,
+        max_drawdown_pct: Decimal | None = None,
+        win_rate: Decimal | None = None,
+        turnover: Decimal | None = None,
+        rank: int | None = None,
+    ) -> TrackLeaderboardEntry:
+        existing = self.session.get(TrackLeaderboardEntry, leaderboard_id)
+        if existing is not None:
+            existing.cumulative_return_pct = cumulative_return_pct
+            existing.sharpe = sharpe
+            existing.sortino = sortino
+            existing.calmar = calmar
+            existing.max_drawdown_pct = max_drawdown_pct
+            existing.win_rate = win_rate
+            existing.turnover = turnover
+            existing.rank = rank
+            self.session.flush()
+            return existing
+        row = TrackLeaderboardEntry(
+            leaderboard_id=leaderboard_id,
+            window_start=window_start,
+            window_end=window_end,
+            track_id=track_id,
+            cumulative_return_pct=cumulative_return_pct,
+            sharpe=sharpe,
+            sortino=sortino,
+            calmar=calmar,
+            max_drawdown_pct=max_drawdown_pct,
+            win_rate=win_rate,
+            turnover=turnover,
+            rank=rank,
+        )
+        self.session.add(row)
+        self.session.flush()
+        return row
+
+    def list_leaderboard(
+        self,
+        *,
+        window_start: dt.date | None = None,
+        window_end: dt.date | None = None,
+    ) -> list[TrackLeaderboardEntry]:
+        stmt = select(TrackLeaderboardEntry)
+        if window_start is not None:
+            stmt = stmt.where(TrackLeaderboardEntry.window_start == window_start)
+        if window_end is not None:
+            stmt = stmt.where(TrackLeaderboardEntry.window_end == window_end)
+        stmt = stmt.order_by(
+            TrackLeaderboardEntry.window_end.desc(),
+            TrackLeaderboardEntry.rank.asc().nullslast(),
+        )
+        return list(self.session.execute(stmt).scalars())
+
+    def upsert_judge_regret(
+        self,
+        *,
+        regret_id: str,
+        judge_agent_id: str,
+        track_id: str,
+        as_of_date: dt.date,
+        selected_reward: Decimal,
+        best_alternative_reward: Decimal,
+        regret: Decimal,
+        observation_count: int,
+    ) -> JudgeRegretEntry:
+        existing = self.session.get(JudgeRegretEntry, regret_id)
+        if existing is not None:
+            existing.selected_reward = selected_reward
+            existing.best_alternative_reward = best_alternative_reward
+            existing.regret = regret
+            existing.observation_count = observation_count
+            self.session.flush()
+            return existing
+        row = JudgeRegretEntry(
+            regret_id=regret_id,
+            judge_agent_id=judge_agent_id,
+            track_id=track_id,
+            as_of_date=as_of_date,
+            selected_reward=selected_reward,
+            best_alternative_reward=best_alternative_reward,
+            regret=regret,
+            observation_count=observation_count,
+        )
+        self.session.add(row)
+        self.session.flush()
+        return row
+
+    def list_judge_regret(
+        self, *, track_id: str | None = None,
+    ) -> list[JudgeRegretEntry]:
+        stmt = select(JudgeRegretEntry)
+        if track_id is not None:
+            stmt = stmt.where(JudgeRegretEntry.track_id == track_id)
+        stmt = stmt.order_by(JudgeRegretEntry.as_of_date.desc())
+        return list(self.session.execute(stmt).scalars())
+
+    def list_recommendations(
+        self,
+        *,
+        run_id: str | None = None,
+        track_id: str | None = None,
+        agent_id: str | None = None,
+    ) -> list[Recommendation]:
+        stmt = select(Recommendation)
+        if run_id is not None:
+            stmt = stmt.where(Recommendation.run_id == run_id)
+        if track_id is not None:
+            stmt = stmt.where(Recommendation.track_id == track_id)
+        if agent_id is not None:
+            stmt = stmt.where(Recommendation.agent_id == agent_id)
+        stmt = stmt.order_by(Recommendation.created_at.desc())
+        return list(self.session.execute(stmt).scalars())
+
+    def list_runs(self, *, limit: int = 50) -> list[Run]:
+        stmt = select(Run).order_by(Run.started_at.desc()).limit(limit)
         return list(self.session.execute(stmt).scalars())
 
 

--- a/src/stockripper/scoring/__init__.py
+++ b/src/stockripper/scoring/__init__.py
@@ -1,0 +1,53 @@
+"""Phase 6 scoring engine (spec §8, §15.2, §25 Phase 6).
+
+Three responsibilities:
+
+1. **Reward** — assign an interim reward score to every
+   :class:`Recommendation` so the dashboard can render per-agent
+   leaderboards within minutes of a window completing.
+2. **Leaderboard** — compute head-to-head per-track summary stats
+   (cumulative return, Sharpe, Sortino, Calmar, max drawdown, win
+   rate, turnover) from ``track_snapshots`` rows.
+3. **Judge regret** — for each (judge, track, date), compare the
+   judge's chosen action against the best alternative the same
+   council could have produced.
+
+Everything in this package is pure logic over already-persisted ledger
+rows; it never makes a network call. Reward/regret evaluation depends
+on a :class:`PriceProvider` so live runs can plug in Alpaca while tests
+use a deterministic stub.
+"""
+
+from __future__ import annotations
+
+from stockripper.scoring.judge_regret import (
+    JudgeRegretReport,
+    compute_judge_regret_for_track,
+    persist_judge_regret_for_track,
+)
+from stockripper.scoring.leaderboard import (
+    LeaderboardMetrics,
+    compute_leaderboard,
+    persist_leaderboard,
+)
+from stockripper.scoring.reward import (
+    PriceObservation,
+    PriceProvider,
+    StaticPriceProvider,
+    aggregate_rewards,
+    score_recommendations_for_window,
+)
+
+__all__ = (
+    "JudgeRegretReport",
+    "LeaderboardMetrics",
+    "PriceObservation",
+    "PriceProvider",
+    "StaticPriceProvider",
+    "aggregate_rewards",
+    "compute_judge_regret_for_track",
+    "compute_leaderboard",
+    "persist_judge_regret_for_track",
+    "persist_leaderboard",
+    "score_recommendations_for_window",
+)

--- a/src/stockripper/scoring/judge_regret.py
+++ b/src/stockripper/scoring/judge_regret.py
@@ -1,0 +1,146 @@
+"""Per-judge regret scoring (spec §8.3, §19.4, §25 Phase 6)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from stockripper.db.models import DecisionAction, JudgeDecision
+from stockripper.db.repository import Repository
+
+
+@dataclass(frozen=True)
+class JudgeRegretReport:
+    judge_agent_id: str
+    track_id: str
+    as_of_date: dt.date
+    selected_reward: Decimal
+    best_alternative_reward: Decimal
+    regret: Decimal
+    observation_count: int
+
+
+def _regret_id(
+    *, judge_agent_id: str, track_id: str, as_of_date: dt.date,
+) -> str:
+    body = f"{judge_agent_id}\x00{track_id}\x00{as_of_date.isoformat()}"
+    return "regret_" + hashlib.sha256(body.encode("utf-8")).hexdigest()[:24]
+
+
+def _avg(values: list[Decimal]) -> Decimal:
+    if not values:
+        return Decimal("0")
+    total = sum(values, start=Decimal("0"))
+    return (total / Decimal(len(values))).quantize(Decimal("0.000001"))
+
+
+def compute_judge_regret_for_track(
+    *,
+    session: Session,
+    run_id: str,
+    track_id: str,
+    as_of_date: dt.date,
+    rewards: Mapping[str, Decimal],
+) -> JudgeRegretReport | None:
+    """Compute a regret report for ``track_id`` within ``run_id``.
+
+    Returns ``None`` when there is no JudgeDecision for the track in
+    that run, or when no scored recommendations exist.
+    """
+
+    repo = Repository(session)
+    decisions = list(
+        session.execute(
+            select(JudgeDecision)
+            .where(JudgeDecision.run_id == run_id)
+            .where(JudgeDecision.track_id == track_id),
+        ).scalars(),
+    )
+    if not decisions:
+        return None
+
+    all_recs = repo.list_recommendations(run_id=run_id, track_id=track_id)
+    if not all_recs:
+        return None
+
+    selected_rec_ids: set[str] = set()
+    for dec in decisions:
+        # MVP approximation: a recommendation is "selected" by the judge
+        # if there is a non-HOLD DecisionAction for the same symbol on
+        # the same track in this decision. Phase 7 will switch this to
+        # the explicit contributing_recommendation_ids carried on the
+        # judge's output_json envelope.
+        actions = list(
+            session.execute(
+                select(DecisionAction)
+                .where(DecisionAction.decision_id == dec.decision_id),
+            ).scalars(),
+        )
+        for action in actions:
+            for rec in all_recs:
+                if rec.symbol.upper() != action.symbol.upper():
+                    continue
+                if rec.action in {"hold", "avoid"}:
+                    continue
+                selected_rec_ids.add(rec.recommendation_id)
+
+    selected_rewards = [
+        rewards[r.recommendation_id]
+        for r in all_recs
+        if r.recommendation_id in selected_rec_ids
+        and r.recommendation_id in rewards
+    ]
+    all_rewards = [
+        rewards[r.recommendation_id]
+        for r in all_recs
+        if r.recommendation_id in rewards
+    ]
+    if not all_rewards:
+        return None
+
+    selected_avg = _avg(selected_rewards)
+    best_alt = max(all_rewards)
+    regret = max(Decimal("0"), best_alt - selected_avg)
+    return JudgeRegretReport(
+        judge_agent_id=decisions[0].judge_agent_id,
+        track_id=track_id,
+        as_of_date=as_of_date,
+        selected_reward=selected_avg.quantize(Decimal("0.000001")),
+        best_alternative_reward=best_alt.quantize(Decimal("0.000001")),
+        regret=regret.quantize(Decimal("0.000001")),
+        observation_count=len(all_rewards),
+    )
+
+
+def persist_judge_regret_for_track(
+    *,
+    session: Session,
+    report: JudgeRegretReport,
+) -> None:
+    Repository(session).upsert_judge_regret(
+        regret_id=_regret_id(
+            judge_agent_id=report.judge_agent_id,
+            track_id=report.track_id,
+            as_of_date=report.as_of_date,
+        ),
+        judge_agent_id=report.judge_agent_id,
+        track_id=report.track_id,
+        as_of_date=report.as_of_date,
+        selected_reward=report.selected_reward,
+        best_alternative_reward=report.best_alternative_reward,
+        regret=report.regret,
+        observation_count=report.observation_count,
+    )
+
+
+__all__ = (
+    "JudgeRegretReport",
+    "compute_judge_regret_for_track",
+    "persist_judge_regret_for_track",
+)

--- a/src/stockripper/scoring/leaderboard.py
+++ b/src/stockripper/scoring/leaderboard.py
@@ -1,0 +1,274 @@
+"""Per-track leaderboard computation (spec §8.3 / §25 Phase 6)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import itertools
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from stockripper.db.models import Fill, Order, TrackSnapshot
+from stockripper.db.repository import Repository
+
+_TRADING_DAYS_PER_YEAR = Decimal("252")
+
+
+@dataclass(frozen=True)
+class LeaderboardMetrics:
+    track_id: str
+    cumulative_return_pct: Decimal | None
+    sharpe: Decimal | None
+    sortino: Decimal | None
+    calmar: Decimal | None
+    max_drawdown_pct: Decimal | None
+    win_rate: Decimal | None
+    turnover: Decimal | None
+
+
+def _leaderboard_id(
+    *, window_start: dt.date, window_end: dt.date, track_id: str,
+) -> str:
+    body = (
+        f"{window_start.isoformat()}\x00{window_end.isoformat()}\x00{track_id}"
+    )
+    return "lb_" + hashlib.sha256(body.encode("utf-8")).hexdigest()[:24]
+
+
+def _daily_snapshots(
+    snaps: Sequence[TrackSnapshot],
+) -> list[TrackSnapshot]:
+    """Collapse to one row per date — the latest snapshot of that day."""
+
+    by_day: dict[dt.date, TrackSnapshot] = {}
+    for s in snaps:
+        existing = by_day.get(s.captured_at.date())
+        if existing is None or s.captured_at > existing.captured_at:
+            by_day[s.captured_at.date()] = s
+    return [by_day[k] for k in sorted(by_day.keys())]
+
+
+def _daily_returns(snaps: Sequence[TrackSnapshot]) -> list[Decimal]:
+    rets: list[Decimal] = []
+    for prev, curr in itertools.pairwise(snaps):
+        if prev.equity == 0:
+            continue
+        rets.append((curr.equity - prev.equity) / prev.equity)
+    return rets
+
+
+def _max_drawdown(snaps: Sequence[TrackSnapshot]) -> Decimal:
+    peak = Decimal("0")
+    worst = Decimal("0")
+    for s in snaps:
+        if s.equity > peak:
+            peak = s.equity
+        if peak > 0:
+            dd = (peak - s.equity) / peak
+            if dd > worst:
+                worst = dd
+    return worst
+
+
+def _std(values: Sequence[Decimal]) -> Decimal:
+    if len(values) < 2:
+        return Decimal("0")
+    mean = sum(values, start=Decimal("0")) / Decimal(len(values))
+    sq = sum(((v - mean) ** 2 for v in values), start=Decimal("0"))
+    var = sq / Decimal(len(values) - 1)
+    return Decimal(str(math.sqrt(float(var))))
+
+
+def _downside_std(values: Sequence[Decimal]) -> Decimal:
+    downs = [v for v in values if v < 0]
+    if len(downs) < 1:
+        return Decimal("0")
+    return _std(downs)
+
+
+def _annualization_factor() -> Decimal:
+    return Decimal(str(math.sqrt(float(_TRADING_DAYS_PER_YEAR))))
+
+
+def _q(value: Decimal | None) -> Decimal | None:
+    if value is None:
+        return None
+    return value.quantize(Decimal("0.000001"))
+
+
+def _compute_metrics(
+    *,
+    track_id: str,
+    snaps: Sequence[TrackSnapshot],
+    turnover: Decimal | None,
+) -> LeaderboardMetrics:
+    daily = _daily_snapshots(snaps)
+    if not daily:
+        return LeaderboardMetrics(
+            track_id=track_id,
+            cumulative_return_pct=None,
+            sharpe=None,
+            sortino=None,
+            calmar=None,
+            max_drawdown_pct=None,
+            win_rate=None,
+            turnover=turnover,
+        )
+    first, last = daily[0], daily[-1]
+    cum: Decimal | None = None
+    if first.equity > 0:
+        cum = (last.equity - first.equity) / first.equity
+
+    rets = _daily_returns(daily)
+    sharpe: Decimal | None = None
+    sortino: Decimal | None = None
+    win_rate: Decimal | None = None
+    if rets:
+        win_rate = (
+            Decimal(sum(1 for r in rets if r > 0)) / Decimal(len(rets))
+        )
+    if len(rets) >= 2:
+        mean = sum(rets, start=Decimal("0")) / Decimal(len(rets))
+        sd = _std(rets)
+        dsd = _downside_std(rets)
+        ann = _annualization_factor()
+        if sd != 0:
+            sharpe = (mean / sd) * ann
+        if dsd != 0:
+            sortino = (mean / dsd) * ann
+
+    mdd = _max_drawdown(daily)
+    calmar: Decimal | None = None
+    if mdd > 0 and cum is not None:
+        calmar = cum / mdd
+
+    return LeaderboardMetrics(
+        track_id=track_id,
+        cumulative_return_pct=_q(cum),
+        sharpe=_q(sharpe),
+        sortino=_q(sortino),
+        calmar=_q(calmar),
+        max_drawdown_pct=_q(mdd) if mdd != 0 else Decimal("0"),
+        win_rate=_q(win_rate),
+        turnover=_q(turnover),
+    )
+
+
+def _track_turnover(
+    *, session: Session, track_id: str,
+    window_start: dt.date, window_end: dt.date,
+) -> Decimal | None:
+    """Sum |notional| for fills inside [window_start, window_end]."""
+
+    end_inclusive = dt.datetime.combine(window_end, dt.time.max, tzinfo=dt.UTC)
+    start_inclusive = dt.datetime.combine(window_start, dt.time.min, tzinfo=dt.UTC)
+    stmt = (
+        select(Fill, Order)
+        .join(Order, Fill.local_order_id == Order.local_order_id)
+        .where(Order.track_id == track_id)
+        .where(Fill.filled_at >= start_inclusive)
+        .where(Fill.filled_at <= end_inclusive)
+    )
+    rows = session.execute(stmt).all()
+    if not rows:
+        return None
+    total = Decimal("0")
+    for fill, _order in rows:
+        total += abs(fill.filled_qty * fill.filled_avg_price)
+    return total
+
+
+def compute_leaderboard(
+    *,
+    session: Session,
+    window_start: dt.date,
+    window_end: dt.date,
+    track_ids: Sequence[str] | None = None,
+) -> list[LeaderboardMetrics]:
+    """Compute per-track leaderboard metrics for the window."""
+
+    repo = Repository(session)
+    tracks = repo.list_strategy_tracks()
+    if track_ids is not None:
+        wanted = set(track_ids)
+        tracks = [t for t in tracks if t.track_id in wanted]
+    end_inclusive = dt.datetime.combine(window_end, dt.time.max, tzinfo=dt.UTC)
+    start_inclusive = dt.datetime.combine(window_start, dt.time.min, tzinfo=dt.UTC)
+    out: list[LeaderboardMetrics] = []
+    for track in tracks:
+        snap_stmt = (
+            select(TrackSnapshot)
+            .where(TrackSnapshot.track_id == track.track_id)
+            .where(TrackSnapshot.captured_at >= start_inclusive)
+            .where(TrackSnapshot.captured_at <= end_inclusive)
+            .order_by(TrackSnapshot.captured_at.asc())
+        )
+        snaps = list(session.execute(snap_stmt).scalars())
+        if not snaps:
+            continue
+        turnover_total = _track_turnover(
+            session=session,
+            track_id=track.track_id,
+            window_start=window_start,
+            window_end=window_end,
+        )
+        turnover: Decimal | None = None
+        if turnover_total is not None:
+            starting = snaps[0].equity or track.starting_equity_usd
+            if starting > 0:
+                turnover = turnover_total / starting
+        metrics = _compute_metrics(
+            track_id=track.track_id, snaps=snaps, turnover=turnover,
+        )
+        out.append(metrics)
+    return out
+
+
+def persist_leaderboard(
+    *,
+    session: Session,
+    window_start: dt.date,
+    window_end: dt.date,
+    metrics: Sequence[LeaderboardMetrics],
+) -> None:
+    """Persist computed metrics, ranking by ``cumulative_return_pct``."""
+
+    repo = Repository(session)
+    ranked = sorted(
+        metrics,
+        key=lambda m: (
+            m.cumulative_return_pct is None,
+            -(m.cumulative_return_pct or Decimal("0")),
+        ),
+    )
+    for i, m in enumerate(ranked, start=1):
+        repo.upsert_leaderboard_entry(
+            leaderboard_id=_leaderboard_id(
+                window_start=window_start,
+                window_end=window_end,
+                track_id=m.track_id,
+            ),
+            window_start=window_start,
+            window_end=window_end,
+            track_id=m.track_id,
+            cumulative_return_pct=m.cumulative_return_pct,
+            sharpe=m.sharpe,
+            sortino=m.sortino,
+            calmar=m.calmar,
+            max_drawdown_pct=m.max_drawdown_pct,
+            win_rate=m.win_rate,
+            turnover=m.turnover,
+            rank=i,
+        )
+
+
+__all__ = (
+    "LeaderboardMetrics",
+    "compute_leaderboard",
+    "persist_leaderboard",
+)

--- a/src/stockripper/scoring/reward.py
+++ b/src/stockripper/scoring/reward.py
@@ -1,0 +1,204 @@
+"""Per-recommendation reward scoring (spec §8.2 / §25 Phase 6)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Final, Protocol
+
+from sqlalchemy.orm import Session
+
+from stockripper.db.repository import Repository
+
+LOG: Final = logging.getLogger(__name__)
+
+_BUY_ACTIONS: Final[frozenset[str]] = frozenset({"buy", "buy_to_open_option"})
+_SELL_ACTIONS: Final[frozenset[str]] = frozenset(
+    {"sell", "short", "cover", "sell_to_open_option"},
+)
+_NEUTRAL_ACTIONS: Final[frozenset[str]] = frozenset({"hold", "avoid", "multi_leg"})
+
+_BENCHMARK_SYMBOL: Final[str] = "SPY"
+
+
+@dataclass(frozen=True)
+class PriceObservation:
+    """One realized (symbol, as_of_date, return_pct) observation."""
+
+    symbol: str
+    as_of_date: dt.date
+    return_pct: Decimal
+
+
+class PriceProvider(Protocol):
+    """Indirection between the scoring engine and price history."""
+
+    def get_realized_return(
+        self,
+        *,
+        symbol: str,
+        from_date: dt.date,
+        horizon_days: int,
+    ) -> Decimal | None: ...
+
+
+@dataclass(frozen=True)
+class StaticPriceProvider:
+    """Deterministic provider backed by a flat dict."""
+
+    table: dict[tuple[str, dt.date, int], Decimal]
+
+    def get_realized_return(
+        self,
+        *,
+        symbol: str,
+        from_date: dt.date,
+        horizon_days: int,
+    ) -> Decimal | None:
+        return self.table.get((symbol.upper(), from_date, horizon_days))
+
+
+def _signed_excess(
+    action: str,
+    sym_return: Decimal,
+    bench_return: Decimal,
+) -> Decimal | None:
+    """Return the directional excess return of one recommendation."""
+
+    excess = sym_return - bench_return
+    if action in _BUY_ACTIONS:
+        return excess
+    if action in _SELL_ACTIONS:
+        return -excess
+    if action in _NEUTRAL_ACTIONS:
+        return Decimal("0")
+    return None
+
+
+def _score_id(
+    *, agent_id: str, track_id: str, as_of_date: dt.date,
+) -> str:
+    body = f"{agent_id}\x00{track_id}\x00{as_of_date.isoformat()}"
+    return "score_" + hashlib.sha256(body.encode("utf-8")).hexdigest()[:24]
+
+
+def aggregate_rewards(rewards: Iterable[Decimal]) -> Decimal:
+    items = list(rewards)
+    if not items:
+        return Decimal("0")
+    total = sum(items, start=Decimal("0"))
+    return (total / Decimal(len(items))).quantize(Decimal("0.000001"))
+
+
+def score_recommendations_for_window(
+    *,
+    session: Session,
+    run_id: str,
+    as_of_date: dt.date,
+    price_provider: PriceProvider,
+    benchmark_symbol: str = _BENCHMARK_SYMBOL,
+) -> list[tuple[str, str, Decimal, int]]:
+    """Score every recommendation tied to ``run_id`` and persist rollups.
+
+    Returns ``(agent_id, track_id, reward_score, observation_count)``
+    tuples in the order they were written.
+    """
+
+    repo = Repository(session)
+    recs = repo.list_recommendations(run_id=run_id)
+    if not recs:
+        return []
+
+    per_rec_rewards: dict[tuple[str, str], list[Decimal]] = {}
+    for rec in recs:
+        bench_ret = price_provider.get_realized_return(
+            symbol=benchmark_symbol,
+            from_date=rec.created_at.date(),
+            horizon_days=int(rec.time_horizon_days),
+        )
+        sym_ret = price_provider.get_realized_return(
+            symbol=rec.symbol,
+            from_date=rec.created_at.date(),
+            horizon_days=int(rec.time_horizon_days),
+        )
+        if bench_ret is None or sym_ret is None:
+            LOG.debug(
+                "Skipping recommendation %s — missing price observation.",
+                rec.recommendation_id,
+            )
+            continue
+        reward = _signed_excess(rec.action, sym_ret, bench_ret)
+        if reward is None:
+            continue
+        per_rec_rewards.setdefault((rec.agent_id, rec.track_id), []).append(
+            reward,
+        )
+
+    out: list[tuple[str, str, Decimal, int]] = []
+    for (agent_id, track_id), rewards in sorted(per_rec_rewards.items()):
+        if not rewards:
+            continue
+        avg = aggregate_rewards(rewards)
+        repo.upsert_agent_score(
+            score_id=_score_id(
+                agent_id=agent_id, track_id=track_id, as_of_date=as_of_date,
+            ),
+            agent_id=agent_id,
+            track_id=track_id,
+            as_of_date=as_of_date,
+            reward_score=avg,
+            observation_count=len(rewards),
+            selected_return_pct=avg,
+        )
+        out.append((agent_id, track_id, avg, len(rewards)))
+    return out
+
+
+def compute_rewards_by_recommendation(
+    *,
+    session: Session,
+    run_id: str,
+    price_provider: PriceProvider,
+    benchmark_symbol: str = _BENCHMARK_SYMBOL,
+) -> dict[str, Decimal]:
+    """Same evaluation as :func:`score_recommendations_for_window` but
+    returns the per-``recommendation_id`` map without persisting.
+
+    Used by :mod:`stockripper.scoring.judge_regret` so regret can run
+    without re-pricing.
+    """
+
+    repo = Repository(session)
+    out: dict[str, Decimal] = {}
+    for rec in repo.list_recommendations(run_id=run_id):
+        bench_ret = price_provider.get_realized_return(
+            symbol=benchmark_symbol,
+            from_date=rec.created_at.date(),
+            horizon_days=int(rec.time_horizon_days),
+        )
+        sym_ret = price_provider.get_realized_return(
+            symbol=rec.symbol,
+            from_date=rec.created_at.date(),
+            horizon_days=int(rec.time_horizon_days),
+        )
+        if bench_ret is None or sym_ret is None:
+            continue
+        reward = _signed_excess(rec.action, sym_ret, bench_ret)
+        if reward is None:
+            continue
+        out[rec.recommendation_id] = reward
+    return out
+
+
+__all__ = (
+    "PriceObservation",
+    "PriceProvider",
+    "StaticPriceProvider",
+    "aggregate_rewards",
+    "compute_rewards_by_recommendation",
+    "score_recommendations_for_window",
+)

--- a/tests/test_dashboard_app.py
+++ b/tests/test_dashboard_app.py
@@ -1,0 +1,175 @@
+"""Tests for the FastAPI dashboard app."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.dashboard import build_app
+from stockripper.dashboard.events import EventBus
+from stockripper.db import Base, Repository, build_engine
+from stockripper.tracks import seed_default_tracks
+
+
+@pytest.fixture
+def session_factory(tmp_path: Path) -> sessionmaker[Session]:
+    db = tmp_path / "dashboard.sqlite"
+    engine = build_engine(f"sqlite:///{db}")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    with factory() as s:
+        seed_default_tracks(s)
+        s.commit()
+    return factory
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus()
+
+
+@pytest.fixture
+def client(
+    session_factory: sessionmaker[Session], event_bus: EventBus,
+) -> TestClient:
+    app = build_app(session_factory=session_factory, event_bus=event_bus)
+    return TestClient(app)
+
+
+def test_health_endpoint(client: TestClient) -> None:
+    resp = client.get("/api/health")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["status"] == "ok"
+    assert "subscribers" in body
+
+
+def test_list_tracks_returns_seeded_tracks(client: TestClient) -> None:
+    resp = client.get("/api/tracks")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) >= 1
+    assert "track_id" in rows[0]
+
+
+def test_runs_list_initially_empty(client: TestClient) -> None:
+    resp = client.get("/api/runs")
+    assert resp.status_code == 200
+    assert resp.json() == []
+
+
+def test_get_run_returns_404_for_unknown(client: TestClient) -> None:
+    resp = client.get("/api/runs/nope")
+    assert resp.status_code == 404
+
+
+def test_get_run_returns_run_and_recommendations(
+    client: TestClient, session_factory: sessionmaker[Session],
+) -> None:
+    with session_factory() as s:
+        repo = Repository(s)
+        repo.create_run(
+            run_id="r_demo",
+            window_label="opening",
+            trading_day=dt.date(2026, 5, 30),
+            config_hash="cfg",
+            started_at=dt.datetime(2026, 5, 30, 14, tzinfo=dt.UTC),
+        )
+        s.commit()
+    resp = client.get("/api/runs/r_demo")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["run"]["run_id"] == "r_demo"
+    assert body["recommendations"] == []
+
+
+def test_leaderboard_filter_by_window(
+    client: TestClient, session_factory: sessionmaker[Session],
+) -> None:
+    with session_factory() as s:
+        repo = Repository(s)
+        track = repo.list_strategy_tracks()[0]
+        repo.upsert_leaderboard_entry(
+            leaderboard_id="lb_demo",
+            window_start=dt.date(2026, 5, 1),
+            window_end=dt.date(2026, 5, 30),
+            track_id=track.track_id,
+            cumulative_return_pct=Decimal("0.08"),
+            rank=1,
+        )
+        s.commit()
+    resp = client.get(
+        "/api/leaderboard?window_start=2026-05-01&window_end=2026-05-30",
+    )
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["rank"] == 1
+    assert rows[0]["cumulative_return_pct"] == "0.080000"
+
+
+def test_agent_scores_filters_by_track(
+    client: TestClient, session_factory: sessionmaker[Session],
+) -> None:
+    with session_factory() as s:
+        repo = Repository(s)
+        track = repo.list_strategy_tracks()[0]
+        repo.upsert_agent_score(
+            score_id="s_demo",
+            agent_id="momentum",
+            track_id=track.track_id,
+            as_of_date=dt.date(2026, 5, 30),
+            reward_score=Decimal("0.02"),
+            observation_count=1,
+        )
+        s.commit()
+    resp = client.get(f"/api/agent-scores?track_id={track.track_id}")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["agent_id"] == "momentum"
+    assert rows[0]["reward_score"] == "0.020000"
+
+
+def test_judge_regret_returns_seeded_rows(
+    client: TestClient, session_factory: sessionmaker[Session],
+) -> None:
+    with session_factory() as s:
+        repo = Repository(s)
+        track = repo.list_strategy_tracks()[0]
+        repo.upsert_judge_regret(
+            regret_id="r_demo",
+            judge_agent_id="judge_calmar",
+            track_id=track.track_id,
+            as_of_date=dt.date(2026, 5, 30),
+            selected_reward=Decimal("0.02"),
+            best_alternative_reward=Decimal("0.05"),
+            regret=Decimal("0.03"),
+            observation_count=2,
+        )
+        s.commit()
+    resp = client.get("/api/judge-regret")
+    assert resp.status_code == 200
+    rows = resp.json()
+    assert len(rows) == 1
+    assert rows[0]["regret"] == "0.030000"
+
+
+def test_invalid_date_returns_400(client: TestClient) -> None:
+    resp = client.get("/api/leaderboard?window_start=not-a-date")
+    assert resp.status_code == 400
+
+
+def test_websocket_endpoint_accepts_connections(
+    client: TestClient,
+) -> None:
+    with client.websocket_connect("/ws/events") as ws:
+        # Closing immediately should not raise; the bus has no subscribers
+        # publishing yet so receive would block. We just exercise the
+        # handshake here.
+        ws.close()

--- a/tests/test_dashboard_events.py
+++ b/tests/test_dashboard_events.py
@@ -1,0 +1,93 @@
+"""Tests for the dashboard event bus + window_runner event emission."""
+
+from __future__ import annotations
+
+import asyncio
+import datetime as dt
+
+import pytest
+
+from stockripper.dashboard.events import (
+    DashboardEvent,
+    EventBus,
+    EventName,
+    NullEventEmitter,
+)
+
+
+@pytest.fixture
+def event_bus() -> EventBus:
+    return EventBus(queue_size=16)
+
+
+async def test_subscribe_receives_published_events(event_bus: EventBus) -> None:
+    received: list[DashboardEvent] = []
+
+    async def consumer() -> None:
+        async for evt in event_bus.subscribe():
+            received.append(evt)
+            if len(received) >= 2:
+                return
+
+    consumer_task = asyncio.create_task(consumer())
+    # Yield once so the consumer can register its queue before we publish.
+    await asyncio.sleep(0)
+    await event_bus.publish(
+        DashboardEvent(event=EventName.WINDOW_STARTED, run_id="r1"),
+    )
+    await event_bus.publish(
+        DashboardEvent(event=EventName.TRACK_STARTED, run_id="r1", track_id="t1"),
+    )
+    await asyncio.wait_for(consumer_task, timeout=2.0)
+
+    assert len(received) == 2
+    assert received[0].event == EventName.WINDOW_STARTED
+    assert received[1].track_id == "t1"
+
+
+async def test_multiple_subscribers_each_receive(event_bus: EventBus) -> None:
+    received_a: list[DashboardEvent] = []
+    received_b: list[DashboardEvent] = []
+
+    async def consume(out: list[DashboardEvent]) -> None:
+        async for evt in event_bus.subscribe():
+            out.append(evt)
+            return
+
+    task_a = asyncio.create_task(consume(received_a))
+    task_b = asyncio.create_task(consume(received_b))
+    await asyncio.sleep(0)
+    await event_bus.publish(
+        DashboardEvent(event=EventName.WINDOW_STARTED, run_id="r1"),
+    )
+    await asyncio.wait_for(asyncio.gather(task_a, task_b), timeout=2.0)
+    assert len(received_a) == 1
+    assert len(received_b) == 1
+    assert received_a[0].event == EventName.WINDOW_STARTED
+    assert received_b[0].event == EventName.WINDOW_STARTED
+
+
+async def test_publish_with_no_subscribers_does_not_raise() -> None:
+    bus = EventBus()
+    await bus.publish(
+        DashboardEvent(event=EventName.WINDOW_STARTED, run_id="r"),
+    )
+
+
+async def test_null_emitter_publish_is_noop() -> None:
+    emitter = NullEventEmitter()
+    await emitter.publish(
+        DashboardEvent(event=EventName.WINDOW_STARTED, run_id="r"),
+    )
+
+
+def test_dashboard_event_is_frozen() -> None:
+    evt = DashboardEvent(event=EventName.TRACK_STARTED, run_id="r1")
+    with pytest.raises(Exception):  # noqa: B017 — pydantic raises ValidationError
+        evt.run_id = "r2"
+
+
+def test_dashboard_event_default_emitted_at_is_utc() -> None:
+    evt = DashboardEvent(event=EventName.WINDOW_STARTED)
+    assert evt.emitted_at.tzinfo is not None
+    assert evt.emitted_at.tzinfo.utcoffset(evt.emitted_at) == dt.timedelta(0)

--- a/tests/test_db_repository_phase6.py
+++ b/tests/test_db_repository_phase6.py
@@ -1,0 +1,129 @@
+"""Tests for Phase 6 repository methods (agent_scores, leaderboard, regret)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.db import Base, Repository, build_engine
+from stockripper.tracks import seed_default_tracks
+
+
+@pytest.fixture
+def session() -> Session:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    return s
+
+
+def _track(session: Session) -> str:
+    return Repository(session).list_strategy_tracks()[0].track_id
+
+
+def test_upsert_agent_score_is_idempotent(session: Session) -> None:
+    repo = Repository(session)
+    track_id = _track(session)
+    row = repo.upsert_agent_score(
+        score_id="score_test",
+        agent_id="momentum_breakout",
+        track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30),
+        reward_score=Decimal("0.0123"),
+        observation_count=4,
+    )
+    assert row.reward_score == Decimal("0.0123")
+
+    row2 = repo.upsert_agent_score(
+        score_id="score_test",
+        agent_id="momentum_breakout",
+        track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30),
+        reward_score=Decimal("-0.005"),
+        observation_count=5,
+    )
+    assert row2.score_id == row.score_id
+    assert row2.reward_score == Decimal("-0.005")
+    assert row2.observation_count == 5
+
+
+def test_list_agent_scores_filters(session: Session) -> None:
+    repo = Repository(session)
+    track_id = _track(session)
+    repo.upsert_agent_score(
+        score_id="s1", agent_id="a1", track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30),
+        reward_score=Decimal("0.01"), observation_count=1,
+    )
+    repo.upsert_agent_score(
+        score_id="s2", agent_id="a2", track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30),
+        reward_score=Decimal("0.05"), observation_count=2,
+    )
+    rows = repo.list_agent_scores(track_id=track_id)
+    assert len(rows) == 2
+    # ordered by reward desc within same date
+    assert rows[0].reward_score >= rows[1].reward_score
+
+    only_a1 = repo.list_agent_scores(track_id=track_id, agent_id="a1")
+    assert len(only_a1) == 1
+    assert only_a1[0].agent_id == "a1"
+
+
+def test_upsert_leaderboard_entry_is_idempotent(session: Session) -> None:
+    repo = Repository(session)
+    track_id = _track(session)
+    row = repo.upsert_leaderboard_entry(
+        leaderboard_id="lb_a",
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+        track_id=track_id,
+        cumulative_return_pct=Decimal("0.07"),
+        rank=1,
+    )
+    assert row.rank == 1
+    row2 = repo.upsert_leaderboard_entry(
+        leaderboard_id="lb_a",
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+        track_id=track_id,
+        cumulative_return_pct=Decimal("0.11"),
+        rank=2,
+    )
+    assert row2.leaderboard_id == "lb_a"
+    assert row2.cumulative_return_pct == Decimal("0.11")
+    assert row2.rank == 2
+
+
+def test_upsert_judge_regret_is_idempotent(session: Session) -> None:
+    repo = Repository(session)
+    track_id = _track(session)
+    row = repo.upsert_judge_regret(
+        regret_id="reg_a",
+        judge_agent_id="judge_calmar",
+        track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30),
+        selected_reward=Decimal("0.02"),
+        best_alternative_reward=Decimal("0.05"),
+        regret=Decimal("0.03"),
+        observation_count=3,
+    )
+    assert row.regret == Decimal("0.03")
+    row2 = repo.upsert_judge_regret(
+        regret_id="reg_a",
+        judge_agent_id="judge_calmar",
+        track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30),
+        selected_reward=Decimal("0.04"),
+        best_alternative_reward=Decimal("0.05"),
+        regret=Decimal("0.01"),
+        observation_count=4,
+    )
+    assert row2.regret_id == "reg_a"
+    assert row2.regret == Decimal("0.01")

--- a/tests/test_scoring_leaderboard.py
+++ b/tests/test_scoring_leaderboard.py
@@ -1,0 +1,165 @@
+"""Tests for the per-track leaderboard scoring engine (Phase 6)."""
+
+from __future__ import annotations
+
+import datetime as dt
+import hashlib
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.db import Base, Repository, build_engine
+from stockripper.db.models import TrackSnapshot
+from stockripper.scoring.leaderboard import (
+    compute_leaderboard,
+    persist_leaderboard,
+)
+from stockripper.tracks import seed_default_tracks
+
+
+@pytest.fixture
+def session() -> Session:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    return s
+
+
+def _snap(track_id: str, day: dt.date, equity: Decimal) -> TrackSnapshot:
+    body = f"{track_id}\x00{day.isoformat()}\x00{equity}"
+    snap_id = "snap_" + hashlib.sha256(body.encode()).hexdigest()[:24]
+    captured = dt.datetime.combine(day, dt.time(20, 0), tzinfo=dt.UTC)
+    return TrackSnapshot(
+        snapshot_id=snap_id,
+        track_id=track_id,
+        captured_at=captured,
+        equity=equity,
+        cash=Decimal("0"),
+    )
+
+
+def _seed_snapshots(
+    session: Session, *, track_id: str, equities: list[Decimal],
+) -> None:
+    start = dt.date(2026, 5, 25)
+    for i, eq in enumerate(equities):
+        session.add(_snap(track_id, start + dt.timedelta(days=i), eq))
+    session.flush()
+
+
+def test_compute_leaderboard_returns_empty_when_no_snapshots(
+    session: Session,
+) -> None:
+    rows = compute_leaderboard(
+        session=session,
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+    )
+    assert rows == []
+
+
+def test_compute_leaderboard_cumulative_return(session: Session) -> None:
+    tracks = Repository(session).list_strategy_tracks()
+    t = tracks[0].track_id
+    _seed_snapshots(
+        session, track_id=t,
+        equities=[
+            Decimal("100000"),
+            Decimal("101000"),
+            Decimal("102000"),
+            Decimal("110000"),
+        ],
+    )
+    rows = compute_leaderboard(
+        session=session,
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+        track_ids=(t,),
+    )
+    assert len(rows) == 1
+    m = rows[0]
+    assert m.track_id == t
+    assert m.cumulative_return_pct == Decimal("0.100000")
+    # Win rate: 3 positive returns out of 3 -> 1.0
+    assert m.win_rate == Decimal("1.000000")
+    assert m.max_drawdown_pct == Decimal("0")
+    assert m.sharpe is not None and m.sharpe > 0
+
+
+def test_compute_leaderboard_max_drawdown(session: Session) -> None:
+    tracks = Repository(session).list_strategy_tracks()
+    t = tracks[0].track_id
+    _seed_snapshots(
+        session, track_id=t,
+        equities=[
+            Decimal("100000"),
+            Decimal("110000"),
+            Decimal("88000"),
+            Decimal("99000"),
+        ],
+    )
+    rows = compute_leaderboard(
+        session=session,
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+        track_ids=(t,),
+    )
+    m = rows[0]
+    # peak=110000, trough=88000 -> (110000-88000)/110000 = 0.2
+    assert m.max_drawdown_pct == Decimal("0.200000")
+
+
+def test_compute_leaderboard_handles_single_snapshot(session: Session) -> None:
+    tracks = Repository(session).list_strategy_tracks()
+    t = tracks[0].track_id
+    _seed_snapshots(
+        session, track_id=t, equities=[Decimal("100000")],
+    )
+    rows = compute_leaderboard(
+        session=session,
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+        track_ids=(t,),
+    )
+    assert len(rows) == 1
+    m = rows[0]
+    assert m.cumulative_return_pct == Decimal("0.000000")
+    assert m.sharpe is None  # need >=2 returns
+    assert m.win_rate is None
+
+
+def test_persist_leaderboard_assigns_ranks(session: Session) -> None:
+    tracks = Repository(session).list_strategy_tracks()
+    assert len(tracks) >= 2
+    t1, t2 = tracks[0].track_id, tracks[1].track_id
+    _seed_snapshots(
+        session, track_id=t1,
+        equities=[Decimal("100000"), Decimal("105000")],
+    )
+    _seed_snapshots(
+        session, track_id=t2,
+        equities=[Decimal("100000"), Decimal("110000")],
+    )
+    metrics = compute_leaderboard(
+        session=session,
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+        track_ids=(t1, t2),
+    )
+    persist_leaderboard(
+        session=session,
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+        metrics=metrics,
+    )
+    rows = Repository(session).list_leaderboard(
+        window_start=dt.date(2026, 5, 1),
+        window_end=dt.date(2026, 5, 30),
+    )
+    by_track = {r.track_id: r for r in rows}
+    assert by_track[t2].rank == 1  # higher cumulative return
+    assert by_track[t1].rank == 2

--- a/tests/test_scoring_regret.py
+++ b/tests/test_scoring_regret.py
@@ -1,0 +1,165 @@
+"""Tests for the judge regret scoring engine (Phase 6)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.db import Base, Repository, build_engine
+from stockripper.db.models import DecisionAction, JudgeDecision, Recommendation
+from stockripper.scoring.judge_regret import (
+    compute_judge_regret_for_track,
+    persist_judge_regret_for_track,
+)
+from stockripper.tracks import seed_default_tracks
+
+
+@pytest.fixture
+def session() -> Session:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    return s
+
+
+def _seed_world(
+    session: Session,
+    *,
+    track_id: str,
+    selected_symbol: str,
+    other_symbols: list[str],
+) -> str:
+    repo = Repository(session)
+    run_id = "run_jr1"
+    repo.create_run(
+        run_id=run_id,
+        window_label="opening",
+        trading_day=dt.date(2026, 5, 30),
+        config_hash="cfg",
+        started_at=dt.datetime(2026, 5, 30, 14, tzinfo=dt.UTC),
+    )
+
+    for i, sym in enumerate([selected_symbol, *other_symbols]):
+        session.add(
+            Recommendation(
+                recommendation_id=f"rec_{i}",
+                run_id=run_id,
+                track_id=track_id,
+                agent_id=f"agent_{i}",
+                symbol=sym,
+                instrument_type="equity",
+                action="buy",
+                conviction=Decimal("0.6"),
+                time_horizon_days=5,
+                thesis="t",
+                schema_valid=True,
+                created_at=dt.datetime(2026, 5, 30, 14, tzinfo=dt.UTC),
+            ),
+        )
+
+    decision = JudgeDecision(
+        decision_id="dec_1",
+        run_id=run_id,
+        track_id=track_id,
+        judge_agent_id="judge_calmar",
+        portfolio_posture="net_long",
+        created_at=dt.datetime(2026, 5, 30, 14, tzinfo=dt.UTC),
+    )
+    session.add(decision)
+    session.flush()
+    session.add(
+        DecisionAction(
+            action_id="act_1",
+            decision_id="dec_1",
+            track_id=track_id,
+            symbol=selected_symbol,
+            instrument_type="equity",
+            action="buy",
+            target_notional_usd=Decimal("1000"),
+        ),
+    )
+    session.flush()
+    return run_id
+
+
+def test_returns_none_when_no_judge_decision(session: Session) -> None:
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    report = compute_judge_regret_for_track(
+        session=session,
+        run_id="run_doesnotexist",
+        track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30),
+        rewards={},
+    )
+    assert report is None
+
+
+def test_regret_is_zero_when_judge_picked_best(session: Session) -> None:
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    run_id = _seed_world(
+        session, track_id=track_id, selected_symbol="BEST",
+        other_symbols=["AAA", "BBB"],
+    )
+    rewards = {
+        "rec_0": Decimal("0.10"),  # BEST — selected
+        "rec_1": Decimal("0.02"),
+        "rec_2": Decimal("-0.01"),
+    }
+    report = compute_judge_regret_for_track(
+        session=session, run_id=run_id, track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30), rewards=rewards,
+    )
+    assert report is not None
+    assert report.judge_agent_id == "judge_calmar"
+    assert report.selected_reward == Decimal("0.100000")
+    assert report.best_alternative_reward == Decimal("0.100000")
+    assert report.regret == Decimal("0.000000")
+    assert report.observation_count == 3
+
+
+def test_regret_positive_when_alternative_better(session: Session) -> None:
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    run_id = _seed_world(
+        session, track_id=track_id, selected_symbol="MEH",
+        other_symbols=["GREAT", "OK"],
+    )
+    rewards = {
+        "rec_0": Decimal("0.02"),  # MEH — selected
+        "rec_1": Decimal("0.15"),  # GREAT — better, ignored
+        "rec_2": Decimal("0.05"),
+    }
+    report = compute_judge_regret_for_track(
+        session=session, run_id=run_id, track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30), rewards=rewards,
+    )
+    assert report is not None
+    assert report.selected_reward == Decimal("0.020000")
+    assert report.best_alternative_reward == Decimal("0.150000")
+    assert report.regret == Decimal("0.130000")
+
+
+def test_persist_judge_regret_roundtrips(session: Session) -> None:
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    run_id = _seed_world(
+        session, track_id=track_id, selected_symbol="X",
+        other_symbols=["Y"],
+    )
+    rewards = {
+        "rec_0": Decimal("0.05"),
+        "rec_1": Decimal("0.10"),
+    }
+    report = compute_judge_regret_for_track(
+        session=session, run_id=run_id, track_id=track_id,
+        as_of_date=dt.date(2026, 5, 30), rewards=rewards,
+    )
+    assert report is not None
+    persist_judge_regret_for_track(session=session, report=report)
+    rows = Repository(session).list_judge_regret(track_id=track_id)
+    assert len(rows) == 1
+    assert rows[0].regret == Decimal("0.050000")

--- a/tests/test_scoring_reward.py
+++ b/tests/test_scoring_reward.py
@@ -1,0 +1,207 @@
+"""Tests for the reward scoring engine (Phase 6)."""
+
+from __future__ import annotations
+
+import datetime as dt
+from decimal import Decimal
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.db import Base, Repository, build_engine
+from stockripper.scoring.reward import (
+    StaticPriceProvider,
+    aggregate_rewards,
+    score_recommendations_for_window,
+)
+from stockripper.tracks import seed_default_tracks
+
+
+@pytest.fixture
+def session() -> Session:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    return s
+
+
+def _seed_run(session: Session, *, run_id: str = "run_t1") -> str:
+    Repository(session).create_run(
+        run_id=run_id,
+        window_label="opening",
+        trading_day=dt.date(2026, 5, 30),
+        config_hash="cfg",
+        started_at=dt.datetime(2026, 5, 30, 14, tzinfo=dt.UTC),
+    )
+    return run_id
+
+
+def _seed_recommendation(
+    session: Session,
+    *,
+    run_id: str,
+    track_id: str,
+    agent_id: str,
+    rec_id: str,
+    symbol: str,
+    action: str,
+    horizon: int = 5,
+) -> None:
+    from stockripper.db.models import Recommendation
+
+    rec = Recommendation(
+        recommendation_id=rec_id,
+        run_id=run_id,
+        track_id=track_id,
+        agent_id=agent_id,
+        symbol=symbol,
+        instrument_type="equity",
+        action=action,
+        conviction=Decimal("0.7"),
+        time_horizon_days=horizon,
+        thesis=f"{action} thesis",
+        schema_valid=True,
+        created_at=dt.datetime(2026, 5, 30, 14, tzinfo=dt.UTC),
+    )
+    session.add(rec)
+    session.flush()
+
+
+def test_aggregate_rewards_handles_empty() -> None:
+    assert aggregate_rewards([]) == Decimal("0")
+
+
+def test_aggregate_rewards_averages() -> None:
+    out = aggregate_rewards([Decimal("0.1"), Decimal("-0.05"), Decimal("0.03")])
+    # (0.1 - 0.05 + 0.03) / 3 = 0.026666...
+    assert out == Decimal("0.026667")
+
+
+def test_score_buy_recommendation_uses_excess_over_benchmark(
+    session: Session,
+) -> None:
+    run_id = _seed_run(session)
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    _seed_recommendation(
+        session, run_id=run_id, track_id=track_id, agent_id="agent_buy",
+        rec_id="rec_buy", symbol="AAPL", action="buy",
+    )
+    base_date = dt.date(2026, 5, 30)
+    provider = StaticPriceProvider(
+        table={
+            ("AAPL", base_date, 5): Decimal("0.10"),  # +10%
+            ("SPY", base_date, 5): Decimal("0.03"),   # +3%
+        },
+    )
+    rows = score_recommendations_for_window(
+        session=session,
+        run_id=run_id,
+        as_of_date=base_date,
+        price_provider=provider,
+    )
+    assert len(rows) == 1
+    agent_id, t_id, reward, n = rows[0]
+    assert agent_id == "agent_buy"
+    assert t_id == track_id
+    assert reward == Decimal("0.070000")
+    assert n == 1
+
+
+def test_score_sell_recommendation_flips_sign(session: Session) -> None:
+    run_id = _seed_run(session)
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    _seed_recommendation(
+        session, run_id=run_id, track_id=track_id, agent_id="agent_short",
+        rec_id="rec_short", symbol="LOSER", action="short",
+    )
+    base_date = dt.date(2026, 5, 30)
+    provider = StaticPriceProvider(
+        table={
+            ("LOSER", base_date, 5): Decimal("-0.05"),
+            ("SPY", base_date, 5): Decimal("0.02"),
+        },
+    )
+    rows = score_recommendations_for_window(
+        session=session, run_id=run_id, as_of_date=base_date,
+        price_provider=provider,
+    )
+    agent_id, _, reward, _ = rows[0]
+    assert agent_id == "agent_short"
+    # excess = -0.05 - 0.02 = -0.07; sell flips sign -> +0.07
+    assert reward == Decimal("0.070000")
+
+
+def test_score_hold_recommendation_is_zero(session: Session) -> None:
+    run_id = _seed_run(session)
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    _seed_recommendation(
+        session, run_id=run_id, track_id=track_id, agent_id="agent_hold",
+        rec_id="rec_hold", symbol="AAPL", action="hold",
+    )
+    base_date = dt.date(2026, 5, 30)
+    provider = StaticPriceProvider(
+        table={
+            ("AAPL", base_date, 5): Decimal("0.10"),
+            ("SPY", base_date, 5): Decimal("0.03"),
+        },
+    )
+    rows = score_recommendations_for_window(
+        session=session, run_id=run_id, as_of_date=base_date,
+        price_provider=provider,
+    )
+    assert rows == [("agent_hold", track_id, Decimal("0.000000"), 1)]
+
+
+def test_score_skips_recommendations_with_missing_prices(session: Session) -> None:
+    run_id = _seed_run(session)
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    _seed_recommendation(
+        session, run_id=run_id, track_id=track_id, agent_id="agent_a",
+        rec_id="rec_a", symbol="UNKNOWN", action="buy",
+    )
+    base_date = dt.date(2026, 5, 30)
+    provider = StaticPriceProvider(table={})  # no entries at all
+    rows = score_recommendations_for_window(
+        session=session, run_id=run_id, as_of_date=base_date,
+        price_provider=provider,
+    )
+    assert rows == []
+
+
+def test_score_rolls_up_multiple_recs_same_agent(session: Session) -> None:
+    run_id = _seed_run(session)
+    track_id = Repository(session).list_strategy_tracks()[0].track_id
+    _seed_recommendation(
+        session, run_id=run_id, track_id=track_id, agent_id="agent_x",
+        rec_id="rec_1", symbol="AAA", action="buy",
+    )
+    _seed_recommendation(
+        session, run_id=run_id, track_id=track_id, agent_id="agent_x",
+        rec_id="rec_2", symbol="BBB", action="buy",
+    )
+    base_date = dt.date(2026, 5, 30)
+    provider = StaticPriceProvider(
+        table={
+            ("AAA", base_date, 5): Decimal("0.10"),
+            ("BBB", base_date, 5): Decimal("0.00"),
+            ("SPY", base_date, 5): Decimal("0.03"),
+        },
+    )
+    rows = score_recommendations_for_window(
+        session=session, run_id=run_id, as_of_date=base_date,
+        price_provider=provider,
+    )
+    assert len(rows) == 1
+    agent_id, _, reward, n = rows[0]
+    assert agent_id == "agent_x"
+    # avg of +0.07 and -0.03 -> 0.02
+    assert reward == Decimal("0.020000")
+    assert n == 2
+    # Verify AgentScore row was upserted
+    scores = Repository(session).list_agent_scores(track_id=track_id)
+    assert len(scores) == 1
+    assert scores[0].reward_score == Decimal("0.020000")
+    assert scores[0].observation_count == 2

--- a/tests/test_window_runner_events.py
+++ b/tests/test_window_runner_events.py
@@ -1,0 +1,97 @@
+"""Tests that ``window_runner.run_window`` emits dashboard events."""
+
+from __future__ import annotations
+
+import datetime as dt
+from collections.abc import Iterable
+
+import pytest
+from sqlalchemy.orm import Session, sessionmaker
+
+from stockripper.agents.canned_llm import CannedCouncilLLM
+from stockripper.agents.registry import build_registry
+from stockripper.agents.schemas import EvidencePacket
+from stockripper.agents.window_runner import run_window
+from stockripper.dashboard.events import DashboardEvent, EventName
+from stockripper.db import Base, build_engine
+from stockripper.tracks import seed_default_tracks
+
+_FROZEN_NOW = dt.datetime(2026, 5, 28, 14, 30, 0, tzinfo=dt.UTC)
+
+
+@pytest.fixture
+def session_factory() -> sessionmaker[Session]:
+    engine = build_engine("sqlite:///:memory:")
+    Base.metadata.create_all(bind=engine)
+    factory = sessionmaker(engine, expire_on_commit=False, autoflush=False)
+    s = factory()
+    seed_default_tracks(s)
+    s.commit()
+    s.close()
+    return factory
+
+
+def _llm_factory(packet: EvidencePacket) -> CannedCouncilLLM:
+    return CannedCouncilLLM(packet=packet, clock=_FROZEN_NOW)
+
+
+class _CaptureEmitter:
+    """Test emitter that captures every published event in order."""
+
+    def __init__(self) -> None:
+        self.events: list[DashboardEvent] = []
+
+    async def publish(self, event: DashboardEvent) -> None:
+        self.events.append(event)
+
+
+def _has(events: Iterable[DashboardEvent], name: EventName) -> bool:
+    return any(e.event == name for e in events)
+
+
+async def test_run_window_emits_lifecycle_events(
+    session_factory: sessionmaker[Session],
+) -> None:
+    emitter = _CaptureEmitter()
+    registry = build_registry()
+    await run_window(
+        registry=registry,
+        track_ids=("balanced",),
+        symbols=("AAPL",),
+        window_label="opening",
+        config_hash="cfg-events",
+        now=_FROZEN_NOW,
+        llm_factory=_llm_factory,
+        session_factory=session_factory,
+        event_emitter=emitter,
+    )
+
+    assert _has(emitter.events, EventName.WINDOW_STARTED)
+    assert _has(emitter.events, EventName.TRACK_STARTED)
+    assert _has(emitter.events, EventName.AGENT_COMPLETED)
+    assert _has(emitter.events, EventName.JUDGE_DECIDED)
+    assert _has(emitter.events, EventName.TRACK_COMPLETED)
+    assert _has(emitter.events, EventName.WINDOW_COMPLETED)
+
+
+async def test_emitter_failure_does_not_break_window(
+    session_factory: sessionmaker[Session],
+) -> None:
+    class _BrokenEmitter:
+        async def publish(self, event: DashboardEvent) -> None:
+            raise RuntimeError("boom")
+
+    registry = build_registry()
+    result = await run_window(
+        registry=registry,
+        track_ids=("balanced",),
+        symbols=("AAPL",),
+        window_label="opening",
+        config_hash="cfg-broken",
+        now=_FROZEN_NOW,
+        llm_factory=_llm_factory,
+        session_factory=session_factory,
+        event_emitter=_BrokenEmitter(),
+    )
+    assert result.status in {"ok", "partial"}
+    assert len(result.outcomes) == 1

--- a/uv.lock
+++ b/uv.lock
@@ -432,6 +432,22 @@ wheels = [
 ]
 
 [[package]]
+name = "fastapi"
+version = "0.136.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "pydantic" },
+    { name = "starlette" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+]
+
+[[package]]
 name = "greenlet"
 version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -506,6 +522,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httptools"
+version = "0.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/43/e5/d471fcb0e14523fe1c3f4ba58ca52480e7bd70ad7109a3846bc75892f7fb/httptools-0.8.0.tar.gz", hash = "sha256:6b2a32f18d97e16e90827d7a819ffa8dbd8cc245fc4e1fa9d1095b54ef4bd999", size = 271342, upload-time = "2026-05-25T22:17:48.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/14/88/1d21a36da8f5cb0fa49eafd4b169eba5608d57e75bbcf61845cbc6243216/httptools-0.8.0-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:880490234c10f70a9830743097e8958d6e4b9f5a0ffc24515023afeef984054d", size = 208247, upload-time = "2026-05-25T22:17:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/42/cc4feea2945cb3051038f090c9b36bd5b8a9d7f5a894a506a8983e33fd1c/httptools-0.8.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5931891fb7b441b8a3853cf1b85c82c903defce084dd5f6771ca46e31bf862c5", size = 113064, upload-time = "2026-05-25T22:17:09.136Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/a6/febbb8b8db0f58b38e44ad6cb946e6a255ae49b55f2e8543408fb7501ccd/httptools-0.8.0-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:b15fc622b0f869d19207c4089a501d9bcc63ca5e071ffdd2f03f922df882dcb2", size = 523851, upload-time = "2026-05-25T22:17:10.106Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/e4/f90a0df0b83beff265b7e3b65f2a4cefd95792d4be0ac3e16049f2acd3c2/httptools-0.8.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:425f83884fd6343828d8c565f046cb72b6d19063f6924093e11bcd8e1548cd09", size = 518842, upload-time = "2026-05-25T22:17:11.218Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/2d/0c9ac76dd2c893841fbf6498d6acec4f2442e1b7067f6e3e316a80e494e8/httptools-0.8.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:ef7c3c97f4311c7be57e2986629df89d49cb434dbff78eafcd48c2bff986b15a", size = 501238, upload-time = "2026-05-25T22:17:12.728Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/42/906adc91ae3a5fa9c59c0a2f21c139725bd7e5b41ae6acd485cd14123ebf/httptools-0.8.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a1afd7c9fbff0d9f5d489c4ce2768bd09c84a46ddefc7161e6aa82ae35c85745", size = 509567, upload-time = "2026-05-25T22:17:13.842Z" },
+    { url = "https://files.pythonhosted.org/packages/05/0b/4240efeb672751ee5b9b380cb0e3fdc050bc05f68adc7a8aefc4fcd9a69a/httptools-0.8.0-cp312-cp312-win_amd64.whl", hash = "sha256:cd96f29b4bab1d42fa6e3d008711c75e0f79e94e06827330160e3a304227f150", size = 90918, upload-time = "2026-05-25T22:17:15.155Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/e5/8cfcabc5546e8022f168be28bcdaa128a240a0befdd03b59d558b4f18bd6/httptools-0.8.0-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:614ceea8ea606848bece2338ac03b3ce5324bcb4be8dc7d377ed708012fa4db8", size = 205148, upload-time = "2026-05-25T22:17:16.333Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/0e/0fb14848c19a686c8062ff9067c1a48793e3224b47bc5b201535b6036fce/httptools-0.8.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2d689918c15a013c65ef52d9fd495d766893ab831a2c8d89f2ac5940a5df847c", size = 111368, upload-time = "2026-05-25T22:17:17.586Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/46f1cecf06b9bbde8e4b8c88034ac7908989e5ff7a3a388ef38392949c1f/httptools-0.8.0-cp313-cp313-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:eb3028cca2fc0a6d720e52ef61d8ebb62fcbfeb1de56874546d858d3f25a26b7", size = 486447, upload-time = "2026-05-25T22:17:18.564Z" },
+    { url = "https://files.pythonhosted.org/packages/77/00/258bfc0837221f81d9725c45f9b948a6a6b2994a147a4fb66e85100c668f/httptools-0.8.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:88bdd940f2b5d487b4d032c6afa5489a7dc4694410d43de3c38c4fb3af0dc45d", size = 482448, upload-time = "2026-05-25T22:17:19.912Z" },
+    { url = "https://files.pythonhosted.org/packages/04/ab/d1cef3b5523f4d272a70f42a776c3169a2dddfe3a54de4b2ce4a36341528/httptools-0.8.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:6a43c9dd399758ccc0531acb0a3c4a6c299ee893ee9400e9c893b7bdcfae0681", size = 464460, upload-time = "2026-05-25T22:17:20.882Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/48/5d1d072442277bb2b3434e0e60690b8e8c23840ef7de8b6ea54040a536d3/httptools-0.8.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:0770728beb05094c809b98e814edff5fef69d26ad7d21185f2f6d5884a0ba683", size = 471312, upload-time = "2026-05-25T22:17:22.085Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/66/b96623b27e51a68199ef4efdda0613cced9233fe3062ac74e50749c5ad37/httptools-0.8.0-cp313-cp313-win_amd64.whl", hash = "sha256:7685df791fad561384bfb139e77fde27a1ffd93134e016f95a0db424ffbf77b1", size = 90117, upload-time = "2026-05-25T22:17:23.074Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/12/fa3fbf5f9517b273edea2dc982aa82a8c634091e67c590792b729017bc6f/httptools-0.8.0-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:de242a49b5d18e0a8776e654e9f6bf6d89f3875a5c35b425a0e7ce940feb3fd6", size = 206183, upload-time = "2026-05-25T22:17:24.004Z" },
+    { url = "https://files.pythonhosted.org/packages/30/fc/5e7c4cb443370f2090a3aba0453a07384d29ff66b7435bb90e77e1037599/httptools-0.8.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:159e9ab5f701ccd42e555a12f1ad8ff69702910fc1c996cf2bb66e5fcb7a231b", size = 112079, upload-time = "2026-05-25T22:17:25.216Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/53/771bd891eb0f236f32145d6a1775777ec85745f3cc983a1f23d1a3b8ddfe/httptools-0.8.0-cp314-cp314-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:c4a9f1707e4823d54dfec6c33fa3697d302aed536ed352a7ebb5a061ddb869d0", size = 481596, upload-time = "2026-05-25T22:17:26.186Z" },
+    { url = "https://files.pythonhosted.org/packages/62/42/94e15bc68ce3d423243c45d7f1b0c7561f13844f97dc52ae23182fb65628/httptools-0.8.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d76ad7b951387e3632c8716a9bb03ac5b45c5f16119aa409db0459520887944e", size = 480865, upload-time = "2026-05-25T22:17:27.542Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/7c/fe2980fc03723272e30f135b62360b075f513dfe7cc73aef36c7f04012bd/httptools-0.8.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:a3b7387147361c3fd47a0bde763c5c91b5b4cd4dc9989b8ece84ff436c99843b", size = 463189, upload-time = "2026-05-25T22:17:28.546Z" },
+    { url = "https://files.pythonhosted.org/packages/15/1b/47fc5fff68acd1bfa20b4734059c9a06cadb88119dcd5258b5b0d21d91c8/httptools-0.8.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:f256d6ce930c52ca1cb2a960b7da03548c454e7d28b06059ad41bfe789036ce0", size = 466610, upload-time = "2026-05-25T22:17:29.816Z" },
+    { url = "https://files.pythonhosted.org/packages/60/bd/07b13c93ffd9bec9546e0d43f8e19378dd696dbd278511406bc07371ef1f/httptools-0.8.0-cp314-cp314-win_amd64.whl", hash = "sha256:19d1ee275bb59ba2643ba9a3a1e51cc0c788caf2b8df506368e03f56fdd08527", size = 92705, upload-time = "2026-05-25T22:17:31.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/c4/121648f68ce066d7bd762d6b6d97e620847642d38d54f3d90ff11d947629/httptools-0.8.0-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:de1ed58a974e75d56560acc7e7fed01a454994429456f65209789992e41f2568", size = 215023, upload-time = "2026-05-25T22:17:32.401Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/b0/312a062ae741ae3e8baa8c8bf20be81b2e67337b259ab4349bebc7b6142e/httptools-0.8.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:e93c227b595c6926c1acee96891dd9da4be338cfbe82e5cd3bb9d8dd7dc4ac0b", size = 117405, upload-time = "2026-05-25T22:17:33.742Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/37/fccd705f795386bb05bf413012fecff2a33e5aa8c2f069096de3e9fd8702/httptools-0.8.0-cp314-cp314t-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:2a021c3a8e65cc125390d72f59b968afca3bdcaff25bd67965e0a055a14946ca", size = 558497, upload-time = "2026-05-25T22:17:34.732Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/39/f172e8003576de35f5ba77ff417cf0e34429d35dc014deef15afa337a72c/httptools-0.8.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48774d39cbb70e2b1f71f88852a3087ae1d3a1eb80482bb48c13067ab080c14f", size = 571585, upload-time = "2026-05-25T22:17:35.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/b9/f5564760af99f3dbbf3f9104dc00e5da27e96cf433c6bdcf77617f70bf3f/httptools-0.8.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:88eead8ec8680a9f146c655bc88445a325bd7921cfd8194c7337e9467282427d", size = 543297, upload-time = "2026-05-25T22:17:37.08Z" },
+    { url = "https://files.pythonhosted.org/packages/99/67/8d9f2c313618e161b82f3873188e7196126da1d6e29688df40eb3997c77a/httptools-0.8.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:2c032fa028f46871ec7e1fc59fc15e8023eab3e6bbe6ece786a1611719a5d081", size = 539535, upload-time = "2026-05-25T22:17:38.032Z" },
+    { url = "https://files.pythonhosted.org/packages/48/63/b906c01e53f50d432c0defe43ce52764a111dc1bdd028bafbeb54dcfd008/httptools-0.8.0-cp314-cp314t-win_amd64.whl", hash = "sha256:384c17174464c8e873398b7af24f0b1f44d992c820328413951a625323155d77", size = 108209, upload-time = "2026-05-25T22:17:39.473Z" },
 ]
 
 [[package]]
@@ -1379,6 +1431,52 @@ wheels = [
 ]
 
 [[package]]
+name = "pyyaml"
+version = "6.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/05/8e/961c0007c59b8dd7729d542c61a4d537767a59645b82a0b521206e1e25c2/pyyaml-6.0.3.tar.gz", hash = "sha256:d76623373421df22fb4cf8817020cbb7ef15c725b9d5e45f17e189bfc384190f", size = 130960, upload-time = "2025-09-25T21:33:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/33/422b98d2195232ca1826284a76852ad5a86fe23e31b009c9886b2d0fb8b2/pyyaml-6.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:7f047e29dcae44602496db43be01ad42fc6f1cc0d8cd6c83d342306c32270196", size = 182063, upload-time = "2025-09-25T21:32:11.445Z" },
+    { url = "https://files.pythonhosted.org/packages/89/a0/6cf41a19a1f2f3feab0e9c0b74134aa2ce6849093d5517a0c550fe37a648/pyyaml-6.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:fc09d0aa354569bc501d4e787133afc08552722d3ab34836a80547331bb5d4a0", size = 173973, upload-time = "2025-09-25T21:32:12.492Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/7a778b6bd0b9a8039df8b1b1d80e2e2ad78aa04171592c8a5c43a56a6af4/pyyaml-6.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9149cad251584d5fb4981be1ecde53a1ca46c891a79788c0df828d2f166bda28", size = 775116, upload-time = "2025-09-25T21:32:13.652Z" },
+    { url = "https://files.pythonhosted.org/packages/65/30/d7353c338e12baef4ecc1b09e877c1970bd3382789c159b4f89d6a70dc09/pyyaml-6.0.3-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5fdec68f91a0c6739b380c83b951e2c72ac0197ace422360e6d5a959d8d97b2c", size = 844011, upload-time = "2025-09-25T21:32:15.21Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9d/b3589d3877982d4f2329302ef98a8026e7f4443c765c46cfecc8858c6b4b/pyyaml-6.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ba1cc08a7ccde2d2ec775841541641e4548226580ab850948cbfda66a1befcdc", size = 807870, upload-time = "2025-09-25T21:32:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/05/c0/b3be26a015601b822b97d9149ff8cb5ead58c66f981e04fedf4e762f4bd4/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8dc52c23056b9ddd46818a57b78404882310fb473d63f17b07d5c40421e47f8e", size = 761089, upload-time = "2025-09-25T21:32:17.56Z" },
+    { url = "https://files.pythonhosted.org/packages/be/8e/98435a21d1d4b46590d5459a22d88128103f8da4c2d4cb8f14f2a96504e1/pyyaml-6.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:41715c910c881bc081f1e8872880d3c650acf13dfa8214bad49ed4cede7c34ea", size = 790181, upload-time = "2025-09-25T21:32:18.834Z" },
+    { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
+    { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/0fd08f8192109f7169db964b5707a2f1e8b745d4e239b784a5a1dd80d1db/pyyaml-6.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:8da9669d359f02c0b91ccc01cac4a67f16afec0dac22c2ad09f46bee0697eba8", size = 181669, upload-time = "2025-09-25T21:32:23.673Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/16/95309993f1d3748cd644e02e38b75d50cbc0d9561d21f390a76242ce073f/pyyaml-6.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:2283a07e2c21a2aa78d9c4442724ec1eb15f5e42a723b99cb3d822d48f5f7ad1", size = 173252, upload-time = "2025-09-25T21:32:25.149Z" },
+    { url = "https://files.pythonhosted.org/packages/50/31/b20f376d3f810b9b2371e72ef5adb33879b25edb7a6d072cb7ca0c486398/pyyaml-6.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ee2922902c45ae8ccada2c5b501ab86c36525b883eff4255313a253a3160861c", size = 767081, upload-time = "2025-09-25T21:32:26.575Z" },
+    { url = "https://files.pythonhosted.org/packages/49/1e/a55ca81e949270d5d4432fbbd19dfea5321eda7c41a849d443dc92fd1ff7/pyyaml-6.0.3-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a33284e20b78bd4a18c8c2282d549d10bc8408a2a7ff57653c0cf0b9be0afce5", size = 841159, upload-time = "2025-09-25T21:32:27.727Z" },
+    { url = "https://files.pythonhosted.org/packages/74/27/e5b8f34d02d9995b80abcef563ea1f8b56d20134d8f4e5e81733b1feceb2/pyyaml-6.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0f29edc409a6392443abf94b9cf89ce99889a1dd5376d94316ae5145dfedd5d6", size = 801626, upload-time = "2025-09-25T21:32:28.878Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/11/ba845c23988798f40e52ba45f34849aa8a1f2d4af4b798588010792ebad6/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7057c9a337546edc7973c0d3ba84ddcdf0daa14533c2065749c9075001090e6", size = 753613, upload-time = "2025-09-25T21:32:30.178Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/e0/7966e1a7bfc0a45bf0a7fb6b98ea03fc9b8d84fa7f2229e9659680b69ee3/pyyaml-6.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:eda16858a3cab07b80edaf74336ece1f986ba330fdb8ee0d6c0d68fe82bc96be", size = 794115, upload-time = "2025-09-25T21:32:31.353Z" },
+    { url = "https://files.pythonhosted.org/packages/de/94/980b50a6531b3019e45ddeada0626d45fa85cbe22300844a7983285bed3b/pyyaml-6.0.3-cp313-cp313-win32.whl", hash = "sha256:d0eae10f8159e8fdad514efdc92d74fd8d682c933a6dd088030f3834bc8e6b26", size = 137427, upload-time = "2025-09-25T21:32:32.58Z" },
+    { url = "https://files.pythonhosted.org/packages/97/c9/39d5b874e8b28845e4ec2202b5da735d0199dbe5b8fb85f91398814a9a46/pyyaml-6.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:79005a0d97d5ddabfeeea4cf676af11e647e41d81c9a7722a193022accdb6b7c", size = 154090, upload-time = "2025-09-25T21:32:33.659Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e8/2bdf3ca2090f68bb3d75b44da7bbc71843b19c9f2b9cb9b0f4ab7a5a4329/pyyaml-6.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:5498cd1645aa724a7c71c8f378eb29ebe23da2fc0d7a08071d89469bf1d2defb", size = 140246, upload-time = "2025-09-25T21:32:34.663Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/8c/f4bd7f6465179953d3ac9bc44ac1a8a3e6122cf8ada906b4f96c60172d43/pyyaml-6.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:8d1fab6bb153a416f9aeb4b8763bc0f22a5586065f86f7664fc23339fc1c1fac", size = 181814, upload-time = "2025-09-25T21:32:35.712Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/9c/4d95bb87eb2063d20db7b60faa3840c1b18025517ae857371c4dd55a6b3a/pyyaml-6.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:34d5fcd24b8445fadc33f9cf348c1047101756fd760b4dacb5c3e99755703310", size = 173809, upload-time = "2025-09-25T21:32:36.789Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b5/47e807c2623074914e29dabd16cbbdd4bf5e9b2db9f8090fa64411fc5382/pyyaml-6.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:501a031947e3a9025ed4405a168e6ef5ae3126c59f90ce0cd6f2bfc477be31b7", size = 766454, upload-time = "2025-09-25T21:32:37.966Z" },
+    { url = "https://files.pythonhosted.org/packages/02/9e/e5e9b168be58564121efb3de6859c452fccde0ab093d8438905899a3a483/pyyaml-6.0.3-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:b3bc83488de33889877a0f2543ade9f70c67d66d9ebb4ac959502e12de895788", size = 836355, upload-time = "2025-09-25T21:32:39.178Z" },
+    { url = "https://files.pythonhosted.org/packages/88/f9/16491d7ed2a919954993e48aa941b200f38040928474c9e85ea9e64222c3/pyyaml-6.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c458b6d084f9b935061bc36216e8a69a7e293a2f1e68bf956dcd9e6cbcd143f5", size = 794175, upload-time = "2025-09-25T21:32:40.865Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/3f/5989debef34dc6397317802b527dbbafb2b4760878a53d4166579111411e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:7c6610def4f163542a622a73fb39f534f8c101d690126992300bf3207eab9764", size = 755228, upload-time = "2025-09-25T21:32:42.084Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ce/af88a49043cd2e265be63d083fc75b27b6ed062f5f9fd6cdc223ad62f03e/pyyaml-6.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:5190d403f121660ce8d1d2c1bb2ef1bd05b5f68533fc5c2ea899bd15f4399b35", size = 789194, upload-time = "2025-09-25T21:32:43.362Z" },
+    { url = "https://files.pythonhosted.org/packages/23/20/bb6982b26a40bb43951265ba29d4c246ef0ff59c9fdcdf0ed04e0687de4d/pyyaml-6.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:4a2e8cebe2ff6ab7d1050ecd59c25d4c8bd7e6f400f5f82b96557ac0abafd0ac", size = 156429, upload-time = "2025-09-25T21:32:57.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/f4/a4541072bb9422c8a883ab55255f918fa378ecf083f5b85e87fc2b4eda1b/pyyaml-6.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:93dda82c9c22deb0a405ea4dc5f2d0cda384168e466364dec6255b293923b2f3", size = 143912, upload-time = "2025-09-25T21:32:59.247Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/f9/07dd09ae774e4616edf6cda684ee78f97777bdd15847253637a6f052a62f/pyyaml-6.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:02893d100e99e03eda1c8fd5c441d8c60103fd175728e23e431db1b589cf5ab3", size = 189108, upload-time = "2025-09-25T21:32:44.377Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/78/8d08c9fb7ce09ad8c38ad533c1191cf27f7ae1effe5bb9400a46d9437fcf/pyyaml-6.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:c1ff362665ae507275af2853520967820d9124984e0f7466736aea23d8611fba", size = 183641, upload-time = "2025-09-25T21:32:45.407Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/5b/3babb19104a46945cf816d047db2788bcaf8c94527a805610b0289a01c6b/pyyaml-6.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6adc77889b628398debc7b65c073bcb99c4a0237b248cacaf3fe8a557563ef6c", size = 831901, upload-time = "2025-09-25T21:32:48.83Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/cc/dff0684d8dc44da4d22a13f35f073d558c268780ce3c6ba1b87055bb0b87/pyyaml-6.0.3-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:a80cb027f6b349846a3bf6d73b5e95e782175e52f22108cfa17876aaeff93702", size = 861132, upload-time = "2025-09-25T21:32:50.149Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/5e/f77dc6b9036943e285ba76b49e118d9ea929885becb0a29ba8a7c75e29fe/pyyaml-6.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:00c4bdeba853cc34e7dd471f16b4114f4162dc03e6b7afcc2128711f0eca823c", size = 839261, upload-time = "2025-09-25T21:32:51.808Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/88/a9db1376aa2a228197c58b37302f284b5617f56a5d959fd1763fb1675ce6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:66e1674c3ef6f541c35191caae2d429b967b99e02040f5ba928632d9a7f0f065", size = 805272, upload-time = "2025-09-25T21:32:52.941Z" },
+    { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
+]
+
+[[package]]
 name = "referencing"
 version = "0.37.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1635,7 +1733,9 @@ source = { editable = "." }
 dependencies = [
     { name = "alembic" },
     { name = "alpaca-py" },
+    { name = "fastapi" },
     { name = "httpx" },
+    { name = "httpx-sse" },
     { name = "mcp" },
     { name = "openai" },
     { name = "psycopg", extra = ["binary"] },
@@ -1645,6 +1745,8 @@ dependencies = [
     { name = "rich" },
     { name = "sqlalchemy" },
     { name = "typer" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "websockets" },
 ]
 
 [package.optional-dependencies]
@@ -1655,6 +1757,7 @@ postgres = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "mypy" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1667,7 +1770,9 @@ dev = [
 requires-dist = [
     { name = "alembic", specifier = ">=1.13" },
     { name = "alpaca-py", specifier = ">=0.30" },
+    { name = "fastapi", specifier = ">=0.136.3" },
     { name = "httpx", specifier = ">=0.27" },
+    { name = "httpx-sse", specifier = ">=0.4.3" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "openai", specifier = ">=1.55" },
     { name = "psycopg", extras = ["binary"], specifier = ">=3.2" },
@@ -1679,11 +1784,14 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0" },
     { name = "sqlalchemy", marker = "extra == 'postgres'", specifier = ">=2.0" },
     { name = "typer", specifier = ">=0.12" },
+    { name = "uvicorn", extras = ["standard"], specifier = ">=0.48.0" },
+    { name = "websockets", specifier = ">=16.0" },
 ]
 provides-extras = ["postgres"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.28.1" },
     { name = "mypy", specifier = ">=1.11" },
     { name = "pytest", specifier = ">=8.3" },
     { name = "pytest-asyncio", specifier = ">=0.24" },
@@ -1778,6 +1886,135 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/e6/bf/f6544ba992ddb9a6077343a576f9844f7f8f06ab819aefd00206e9255f18/uvicorn-0.48.0.tar.gz", hash = "sha256:a5504207195d08c2511bf9125ede5ac4a4b71725d519e758d01dcf0bc2d31c37", size = 91074, upload-time = "2026-05-24T12:08:41.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/01/be/72532be3da7acc5fdfbccdb95215cd04f995a0886532a5b423f929cda4cc/uvicorn-0.48.0-py3-none-any.whl", hash = "sha256:48097851328b87ec36117d3d575234519eb58c2b22d79666e9bbc6c49a761dad", size = 71410, upload-time = "2026-05-24T12:08:40.258Z" },
+]
+
+[package.optional-dependencies]
+standard = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "httptools" },
+    { name = "python-dotenv" },
+    { name = "pyyaml" },
+    { name = "uvloop", marker = "platform_python_implementation != 'PyPy' and sys_platform != 'cygwin' and sys_platform != 'win32'" },
+    { name = "watchfiles" },
+    { name = "websockets" },
+]
+
+[[package]]
+name = "uvloop"
+version = "0.22.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/06/f0/18d39dbd1971d6d62c4629cc7fa67f74821b0dc1f5a77af43719de7936a7/uvloop-0.22.1.tar.gz", hash = "sha256:6c84bae345b9147082b17371e3dd5d42775bddce91f885499017f4607fdaf39f", size = 2443250, upload-time = "2025-10-16T22:17:19.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/ff/7f72e8170be527b4977b033239a83a68d5c881cc4775fca255c677f7ac5d/uvloop-0.22.1-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:fe94b4564e865d968414598eea1a6de60adba0c040ba4ed05ac1300de402cd42", size = 1359936, upload-time = "2025-10-16T22:16:29.436Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/c6/e5d433f88fd54d81ef4be58b2b7b0cea13c442454a1db703a1eea0db1a59/uvloop-0.22.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:51eb9bd88391483410daad430813d982010f9c9c89512321f5b60e2cddbdddd6", size = 752769, upload-time = "2025-10-16T22:16:30.493Z" },
+    { url = "https://files.pythonhosted.org/packages/24/68/a6ac446820273e71aa762fa21cdcc09861edd3536ff47c5cd3b7afb10eeb/uvloop-0.22.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:700e674a166ca5778255e0e1dc4e9d79ab2acc57b9171b79e65feba7184b3370", size = 4317413, upload-time = "2025-10-16T22:16:31.644Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/6f/e62b4dfc7ad6518e7eff2516f680d02a0f6eb62c0c212e152ca708a0085e/uvloop-0.22.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7b5b1ac819a3f946d3b2ee07f09149578ae76066d70b44df3fa990add49a82e4", size = 4426307, upload-time = "2025-10-16T22:16:32.917Z" },
+    { url = "https://files.pythonhosted.org/packages/90/60/97362554ac21e20e81bcef1150cb2a7e4ffdaf8ea1e5b2e8bf7a053caa18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:e047cc068570bac9866237739607d1313b9253c3051ad84738cbb095be0537b2", size = 4131970, upload-time = "2025-10-16T22:16:34.015Z" },
+    { url = "https://files.pythonhosted.org/packages/99/39/6b3f7d234ba3964c428a6e40006340f53ba37993f46ed6e111c6e9141d18/uvloop-0.22.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:512fec6815e2dd45161054592441ef76c830eddaad55c8aa30952e6fe1ed07c0", size = 4296343, upload-time = "2025-10-16T22:16:35.149Z" },
+    { url = "https://files.pythonhosted.org/packages/89/8c/182a2a593195bfd39842ea68ebc084e20c850806117213f5a299dfc513d9/uvloop-0.22.1-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:561577354eb94200d75aca23fbde86ee11be36b00e52a4eaf8f50fb0c86b7705", size = 1358611, upload-time = "2025-10-16T22:16:36.833Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/14/e301ee96a6dc95224b6f1162cd3312f6d1217be3907b79173b06785f2fe7/uvloop-0.22.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cdf5192ab3e674ca26da2eada35b288d2fa49fdd0f357a19f0e7c4e7d5077c8", size = 751811, upload-time = "2025-10-16T22:16:38.275Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/02/654426ce265ac19e2980bfd9ea6590ca96a56f10c76e63801a2df01c0486/uvloop-0.22.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6e2ea3d6190a2968f4a14a23019d3b16870dd2190cd69c8180f7c632d21de68d", size = 4288562, upload-time = "2025-10-16T22:16:39.375Z" },
+    { url = "https://files.pythonhosted.org/packages/15/c0/0be24758891ef825f2065cd5db8741aaddabe3e248ee6acc5e8a80f04005/uvloop-0.22.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0530a5fbad9c9e4ee3f2b33b148c6a64d47bbad8000ea63704fa8260f4cf728e", size = 4366890, upload-time = "2025-10-16T22:16:40.547Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/53/8369e5219a5855869bcee5f4d317f6da0e2c669aecf0ef7d371e3d084449/uvloop-0.22.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:bc5ef13bbc10b5335792360623cc378d52d7e62c2de64660616478c32cd0598e", size = 4119472, upload-time = "2025-10-16T22:16:41.694Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ba/d69adbe699b768f6b29a5eec7b47dd610bd17a69de51b251126a801369ea/uvloop-0.22.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1f38ec5e3f18c8a10ded09742f7fb8de0108796eb673f30ce7762ce1b8550cad", size = 4239051, upload-time = "2025-10-16T22:16:43.224Z" },
+    { url = "https://files.pythonhosted.org/packages/90/cd/b62bdeaa429758aee8de8b00ac0dd26593a9de93d302bff3d21439e9791d/uvloop-0.22.1-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:3879b88423ec7e97cd4eba2a443aa26ed4e59b45e6b76aabf13fe2f27023a142", size = 1362067, upload-time = "2025-10-16T22:16:44.503Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/f8/a132124dfda0777e489ca86732e85e69afcd1ff7686647000050ba670689/uvloop-0.22.1-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:4baa86acedf1d62115c1dc6ad1e17134476688f08c6efd8a2ab076e815665c74", size = 752423, upload-time = "2025-10-16T22:16:45.968Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/94/94af78c156f88da4b3a733773ad5ba0b164393e357cc4bd0ab2e2677a7d6/uvloop-0.22.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:297c27d8003520596236bdb2335e6b3f649480bd09e00d1e3a99144b691d2a35", size = 4272437, upload-time = "2025-10-16T22:16:47.451Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/35/60249e9fd07b32c665192cec7af29e06c7cd96fa1d08b84f012a56a0b38e/uvloop-0.22.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:c1955d5a1dd43198244d47664a5858082a3239766a839b2102a269aaff7a4e25", size = 4292101, upload-time = "2025-10-16T22:16:49.318Z" },
+    { url = "https://files.pythonhosted.org/packages/02/62/67d382dfcb25d0a98ce73c11ed1a6fba5037a1a1d533dcbb7cab033a2636/uvloop-0.22.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31dc2fccbd42adc73bc4e7cdbae4fc5086cf378979e53ca5d0301838c5682c6", size = 4114158, upload-time = "2025-10-16T22:16:50.517Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/7a/f1171b4a882a5d13c8b7576f348acfe6074d72eaf52cccef752f748d4a9f/uvloop-0.22.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:93f617675b2d03af4e72a5333ef89450dfaa5321303ede6e67ba9c9d26878079", size = 4177360, upload-time = "2025-10-16T22:16:52.646Z" },
+    { url = "https://files.pythonhosted.org/packages/79/7b/b01414f31546caf0919da80ad57cbfe24c56b151d12af68cee1b04922ca8/uvloop-0.22.1-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:37554f70528f60cad66945b885eb01f1bb514f132d92b6eeed1c90fd54ed6289", size = 1454790, upload-time = "2025-10-16T22:16:54.355Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/31/0bb232318dd838cad3fa8fb0c68c8b40e1145b32025581975e18b11fab40/uvloop-0.22.1-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:b76324e2dc033a0b2f435f33eb88ff9913c156ef78e153fb210e03c13da746b3", size = 796783, upload-time = "2025-10-16T22:16:55.906Z" },
+    { url = "https://files.pythonhosted.org/packages/42/38/c9b09f3271a7a723a5de69f8e237ab8e7803183131bc57c890db0b6bb872/uvloop-0.22.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:badb4d8e58ee08dad957002027830d5c3b06aea446a6a3744483c2b3b745345c", size = 4647548, upload-time = "2025-10-16T22:16:57.008Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/37/945b4ca0ac27e3dc4952642d4c900edd030b3da6c9634875af6e13ae80e5/uvloop-0.22.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b91328c72635f6f9e0282e4a57da7470c7350ab1c9f48546c0f2866205349d21", size = 4467065, upload-time = "2025-10-16T22:16:58.206Z" },
+    { url = "https://files.pythonhosted.org/packages/97/cc/48d232f33d60e2e2e0b42f4e73455b146b76ebe216487e862700457fbf3c/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:daf620c2995d193449393d6c62131b3fbd40a63bf7b307a1527856ace637fe88", size = 4328384, upload-time = "2025-10-16T22:16:59.36Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/c1fd27e9549f3c4baf1dc9c20c456cd2f822dbf8de9f463824b0c0357e06/uvloop-0.22.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:6cde23eeda1a25c75b2e07d39970f3374105d5eafbaab2a4482be82f272d5a5e", size = 4296730, upload-time = "2025-10-16T22:17:00.744Z" },
+]
+
+[[package]]
+name = "watchfiles"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cd/41/5e1a4bb12aac5f1493fa1bdc11154eca3b258ca4eba65d39c473fe19d8e9/watchfiles-1.2.0.tar.gz", hash = "sha256:c995fba777f1ea992f090f9236e9284cf7a5d1a0130dd5a3d82c598cacd76838", size = 108252, upload-time = "2026-05-18T04:32:04.251Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b8/2f/e42c992d2afda3108ea1c02acecc991b9f31d05c14adc2a7cee9ee211fc4/watchfiles-1.2.0-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:bc13eb17538be00c874699dc0abe4ee2bc8d50bb1166a6b9e175ef3fd7eb8f26", size = 400115, upload-time = "2026-05-18T04:32:02.06Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/8f/6af2ea19065c91d8b0ea3516fdfc8c0d349f407e8e9fbf4e5a17360de8ad/watchfiles-1.2.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:2d95ddc1eb6914154253d239089900813f6a767e174b8e6a50e7fdacb7e4236c", size = 393659, upload-time = "2026-05-18T04:30:50.951Z" },
+    { url = "https://files.pythonhosted.org/packages/13/01/b32a967c56fb3e3e5be3db52c3d3b87fa4513aa367d8ed1ad96d42952e5f/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f70d8b291ef6e88d19b1f297a6905ddb978888d9272b0d05e6f53309856bcfc", size = 453207, upload-time = "2026-05-18T04:31:04.231Z" },
+    { url = "https://files.pythonhosted.org/packages/04/98/97557a812180338cb1abd32e1cffcc4588f59b5f23e0cb006b2ba95ba64a/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:56d8641cf834c2836922899105bd3ce3d0dfc69291d52edf0b4d0436829b34c0", size = 459273, upload-time = "2026-05-18T04:31:50.377Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/a8/b4b08dcb7653b8087c6586f7ce649505900e866bbcfe40dc9587af02e686/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2581a94056e55d7d0a31a823ea92bf73749c489ca2285bfdc0fbe6b2bb49d50c", size = 489927, upload-time = "2026-05-18T04:31:42.485Z" },
+    { url = "https://files.pythonhosted.org/packages/50/94/3dceea03545d2e5ddfd839f0ddd5e1cecbf1697b5a428d5ba11cef6af95d/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:41bc1199f7523b3f82843c88cbb979180c949caef0342cf90968f178e5d49b01", size = 570476, upload-time = "2026-05-18T04:31:03.071Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/f2/d39a5450c3532092b91f81d274360e613c2371bc874a89c7a1a3c5e8d138/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:7571e4464cb6e434958f867f7f730b8ab0b75e3f8e5eac0499168486ab3c33a8", size = 465650, upload-time = "2026-05-18T04:30:12.701Z" },
+    { url = "https://files.pythonhosted.org/packages/22/24/ed72f68cbc1333ca9b9f2200aa048bb6658ae41709bc1caad4310f4bdffd/watchfiles-1.2.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e53a384f76b631c3ae5334ce6a52f0baa3a911eb94a4eac7f160079868b716d5", size = 456398, upload-time = "2026-05-18T04:30:13.784Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/64/982ef4a4e5bab5b6e5b6becc8cd5e732f6130a78b855f0abec6439a9a135/watchfiles-1.2.0-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:d20029a60a71a052a24c4db7673bc4de39ab89adbaccbfb5d67987c5d73f424d", size = 465140, upload-time = "2026-05-18T04:31:52.111Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/0c/95282abf4ed680b6096010bcfc30c5fa7a041fc5aa5a2ad17a2cc6c75bba/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:2cb93af48550faf1cea04c303107c8b75833de7013e57ce27d3b8d21d8d0f58c", size = 630259, upload-time = "2026-05-18T04:31:25.676Z" },
+    { url = "https://files.pythonhosted.org/packages/30/45/607c1de1530c4bdcf2cf1d1ecc2505ddba5d96bd43ba9f2b0e79876f850f/watchfiles-1.2.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2995c176de7692b86a2e4c58d9ec718f753150a979cb4a754e2b4ffa38e70906", size = 659859, upload-time = "2026-05-18T04:30:24.333Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/08/d9e2e0f9e8e6791d33aefc694ad7eefa7f901f63caff84a81ded38692f9c/watchfiles-1.2.0-cp312-cp312-win32.whl", hash = "sha256:7a2cffd17d27d2ecbb310c2b1d8174f222a5495b1a721894afa88ec11e25b898", size = 275480, upload-time = "2026-05-18T04:30:31.307Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/e6/9d42569c0102645cc8cea5d8c7d8a1e9d4ada2cb7f05f75e554b8aa2202a/watchfiles-1.2.0-cp312-cp312-win_amd64.whl", hash = "sha256:f155b3a1b2a5fc89cdc70d47ee5d54e3b75e88efa34982028a35daef9ba00379", size = 288718, upload-time = "2026-05-18T04:32:10.745Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/26/88e0dc6ee3898169d7fa22bb6a69cabf2502d2ee25cb8c876d1262d204f8/watchfiles-1.2.0-cp312-cp312-win_arm64.whl", hash = "sha256:8fa585ede612ee9f9e91b18bebf9ba11b9ae29a4e3a0d0cf6fca3e382133f0d5", size = 281026, upload-time = "2026-05-18T04:30:22.23Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/4d/70a7feced9f87e2ff26dba42667290f41694fc64646c67261fbb8cab5d5c/watchfiles-1.2.0-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:01ea8d66f0693b9b60a6541c8d10263091ca9a9060d242f3c1f3143f9aad2c98", size = 399730, upload-time = "2026-05-18T04:31:38.162Z" },
+    { url = "https://files.pythonhosted.org/packages/31/3a/0da302f2307aee316922806ebd5726c542cbd787c938271cf14a074c7daf/watchfiles-1.2.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:7ba0480b9a74af058f43b337e937a451e109295c420916d68ad24e3dc02f5e44", size = 392842, upload-time = "2026-05-18T04:30:27.051Z" },
+    { url = "https://files.pythonhosted.org/packages/db/ef/d5bdb705c224dbc256aa0c1ec47bf4e61ec52558f2afb44a71a1fe4d7015/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4f34e26a19f91f710c08e0183429f0d1d15df734e6bc78c31e77b9ea9c433658", size = 452989, upload-time = "2026-05-18T04:31:11.945Z" },
+    { url = "https://files.pythonhosted.org/packages/71/29/5495f2c1661949ef7a35e4d71111d129cfe7606414a26887a919d0a55406/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b4e77f6a55f858504069abd35d336a637555c09bca453dde1ee1e5ada8a6a1fb", size = 458978, upload-time = "2026-05-18T04:30:52.606Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/7f9c07c433811c2fffd93e13fdfb7135de9aab5f2ae41be08960fa0047dc/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0cb4d80e212f116474a545c21c912b445f16bb0cef9e6a73a498164223e14e2f", size = 490248, upload-time = "2026-05-18T04:31:36.003Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/11/d93632febc52fbc21be90231bb7c17fd5387f46c9076fd40a5f9c2ae6910/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b974946a10af379d425e2eef5b62f5c6ebeaccf91d45eaad6f5b27ecd4f91aa0", size = 571847, upload-time = "2026-05-18T04:31:10.862Z" },
+    { url = "https://files.pythonhosted.org/packages/55/b4/383173e73aabb07ad1d9c7aa859d95437ac46a6d6a1e11005facda0c9d19/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:86bc13c25a8d1fcd70b51d0ce7c9b65e90de5666fcbfd3e34957cc73ee19aeb5", size = 465974, upload-time = "2026-05-18T04:30:17.006Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/6c/89b1a230a78f57c52dd8893adb1f92f94411721b6ec12596c56d98c74356/watchfiles-1.2.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ca148d73dea36c9763aaa351e4d7a51780ec1584217c45276f4fe8239c768b71", size = 454782, upload-time = "2026-05-18T04:30:35.656Z" },
+    { url = "https://files.pythonhosted.org/packages/24/62/1732118367cfff0a9fce3bf62ff4bfded09ef5df21d9d446b858b3f70a96/watchfiles-1.2.0-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:c525543d91961c6955b2636b308569e84a1d1c5f5f2932041ab9ef46422f43e3", size = 465182, upload-time = "2026-05-18T04:30:20.846Z" },
+    { url = "https://files.pythonhosted.org/packages/28/96/716f7e5f51339bf22963f3345f9f27d7f3b30e2eadc597e257c881dd3c53/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:a204794696ffb8f9b10fba6f7cb5216d42f3b2b71860ccac6b6e42f5f10973b0", size = 629841, upload-time = "2026-05-18T04:31:05.397Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/fe/c40783950fd771ccf66ab3ec2722d188a9af1c7f96c6e811f36e40c6e03f/watchfiles-1.2.0-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:10d86db20695afe7997ac9e1717637d6714a8d0220458c33f3d2061f54cec427", size = 658028, upload-time = "2026-05-18T04:31:48.22Z" },
+    { url = "https://files.pythonhosted.org/packages/71/72/4508db1856d1d87fcbb3b63f4839bab1b5682cb0e8d224d122263c09654a/watchfiles-1.2.0-cp313-cp313-win32.whl", hash = "sha256:eb283ee99e21ad6443c8cdb06ac5b34b1308c329cbdf03fa02b445363714c799", size = 275183, upload-time = "2026-05-18T04:30:59.57Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/36/14b76ca57652e5cc5fd1c11f32a261292c08a0d19a00351013c2549cbfb2/watchfiles-1.2.0-cp313-cp313-win_amd64.whl", hash = "sha256:a0f27f01bee51861392bb6b7c4fdb290b27d1eb194e9e28788d68102a0e898d9", size = 288059, upload-time = "2026-05-18T04:32:07.937Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/8d/0a85e395398d8d20fadfe5c5d32c726eee17a519e78fb356f2cf7531bffe/watchfiles-1.2.0-cp313-cp313-win_arm64.whl", hash = "sha256:3651aa7058595e9cfb75d35dd5ada2bf9f48a5b8a0f3562821d3e210c507e077", size = 280186, upload-time = "2026-05-18T04:31:54.484Z" },
+    { url = "https://files.pythonhosted.org/packages/37/68/36db056f1fdcc5f07302f56e631774d6835bcd6fa3ace402304621d5f9e5/watchfiles-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:faea288b6f0ab1902ef08f4ca6de005dccf856c4e0c4f21b8c5fce02d90a1b08", size = 399031, upload-time = "2026-05-18T04:30:44.576Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/64/01a9d6f66a82a5c101ce939274106cc72759d62427e153f01edd2b9f87c2/watchfiles-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:01859b11fd9fbca670f4d5da00fbac282cfea9bd67a2125d8b2833a3b5617ea9", size = 391205, upload-time = "2026-05-18T04:30:25.413Z" },
+    { url = "https://files.pythonhosted.org/packages/84/2c/0a44fe058cb4bb7b8ede6b6670698bbb7c0400740e378d00022189b7b31d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fff610d7bb2256a317bb1e96f0d7862c7aa8076733ee5df0fd41bbe76a24a4f4", size = 451892, upload-time = "2026-05-18T04:32:14.005Z" },
+    { url = "https://files.pythonhosted.org/packages/67/a1/351e0d56cd35e6488b5c8b4fb11a809a5bc923e8fe8fed9faf8920be0c89/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b141a4891c995a039cd89e9a49e62df1dc8a559a5d1a6e4c7106d16c12777a55", size = 458867, upload-time = "2026-05-18T04:31:22.279Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/7d/9d09605187f1b838998624049fcf8bf47b73c1a3b76901fcac1782f62277/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22943b7770483f6ea0721c6b11d022947a98eb0acae14694de034f4d0d38925", size = 490217, upload-time = "2026-05-18T04:31:43.657Z" },
+    { url = "https://files.pythonhosted.org/packages/60/5d/a17a16eccb182f04188cd308ec24b1a71a9b5c4e7098269cf35d9fa56d02/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:1bc6195825b7dcd217968bb1f801a60fd4c16e8eeab5bedc7fe917d7d5995ab4", size = 571458, upload-time = "2026-05-18T04:32:11.875Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/3d/4dd457062083ab1938e5dfd45032eb425cee2ac817287ca8ff4356183e5d/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:d4a4b147f5dca2a5d325a06a832fb43f345751adfbc63204aec30e0d9ca965a2", size = 464707, upload-time = "2026-05-18T04:30:43.492Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/71/ea8c57b128f5383de74d0c7d2d9c57ad7c9a65a930c451bd25d524b295b7/watchfiles-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4543579a9bdb0c9560039b4ffddbdb39545707659fbc430ce4c10f3f68d557f9", size = 454663, upload-time = "2026-05-18T04:30:16.061Z" },
+    { url = "https://files.pythonhosted.org/packages/53/fd/2e812bf938406d7db351f0703ddd3fc6c061cf30d96153a77bc79a943a44/watchfiles-1.2.0-cp313-cp313t-manylinux_2_31_riscv64.whl", hash = "sha256:20aa0e708b920bde876a4aa82dc7dd6ebea228a63a67cda6632c2fc87b787efa", size = 463537, upload-time = "2026-05-18T04:31:44.9Z" },
+    { url = "https://files.pythonhosted.org/packages/86/56/d17a7f1dd1bc3035f1072694a551301272f1739c2d8e319c927cb9e29b38/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_aarch64.whl", hash = "sha256:d413349d565dab74297f2a63e84a097936be69bf8f3b3801f27f380e32040f44", size = 629194, upload-time = "2026-05-18T04:31:14.141Z" },
+    { url = "https://files.pythonhosted.org/packages/be/06/f1ff66bf5cae50aa4062779a0ecd0bbaf15e466195719074078947d9a17d/watchfiles-1.2.0-cp313-cp313t-musllinux_1_1_x86_64.whl", hash = "sha256:f28b2725eb8cce327b9b3ab02415c853011dc55c95832fe90de6bc56f5315f72", size = 656194, upload-time = "2026-05-18T04:31:47.14Z" },
+    { url = "https://files.pythonhosted.org/packages/e7/54/a9c7ea9a82a4ac65e7004c0a03920b5cdd2f9c3b678757d9cd425aa51d53/watchfiles-1.2.0-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:b8c8358484d5fa12ef34f05b7f4168eaf1932f408725ff6d023c33ec17bd79d4", size = 400205, upload-time = "2026-05-18T04:32:05.153Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5d/c9ab3534374a4a67450696905d6ef16a04405448b8dc52bd752ae50423d4/watchfiles-1.2.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:9f04b092229ad2c50126dd3c922c8822e51e605993764a33058d4a791ab42281", size = 392508, upload-time = "2026-05-18T04:30:54.849Z" },
+    { url = "https://files.pythonhosted.org/packages/26/ca/1ad30103535cf0cecd7b993e8d50edc5351b1820e38f2d22e3df58962feb/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7a7ce236284f002a156f70add88efe5c70879cccbb658be0822c54b1306fc09d", size = 452448, upload-time = "2026-05-18T04:30:53.727Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a1/ceee2cdf2afbd715fa07758d39c9859513eae411b23196f7fd039e5feedd/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:b9909cc2b48468b575eefa944919e1fe8a36c5849d5c7c168f80a8c1db69398e", size = 459605, upload-time = "2026-05-18T04:30:23.312Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/f6/421e30fd1cb3907a84ed92ab3f1983e37ba2dca015e9a894a048418417a2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:0a37faaed405c67e28e6be45a1fa4f206ef5a2860f27c237db9fa30704c38242", size = 490757, upload-time = "2026-05-18T04:30:47.358Z" },
+    { url = "https://files.pythonhosted.org/packages/41/b0/55ed1b97ed08be7bba6f9a541cac15f2a858e1d74d2b07b6da70a82aab00/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9649193aa27bd9ff2e80ff29bfaa93085496c7a3a377592823cc58b77ee88add", size = 568672, upload-time = "2026-05-18T04:30:38.915Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/cf/d8ae8a80dd7bafab395ea7681c10237311bbf34d37704a8c744e7cf31fc7/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:4e4ff8e37f99cf1da89e255e07c9c4b37c214038c4283707bdec308cb1b0ea1f", size = 464197, upload-time = "2026-05-18T04:30:09.914Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/8a/3076c496ca8dafe0e8cd03fcebdfc47be4b1174b4e5b24ff6e396e6b3af2/watchfiles-1.2.0-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:054dc20fd2e3132b4c3883b4a00d72fd6e1f56fdaf89fccd12e8057d74cd74d7", size = 453181, upload-time = "2026-05-18T04:30:14.829Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/10/9745e17c98e7b8a86454df0a3c7b5686bd650383f1e9f26e4ebcbd6cc0c0/watchfiles-1.2.0-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:e140ed30ebde76796b686e67c182cff10ea2fbab186fafd1560f74bb5a473a6e", size = 465109, upload-time = "2026-05-18T04:30:28.123Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/95/8ef4a95481d3e0cb52d62a06fa6e972e81424be2d9698b91a2fecca9904c/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:bb7e52ecf68ba46d22df23467b87cffeb2146908aa523ebfe803019618cfda06", size = 630653, upload-time = "2026-05-18T04:31:49.304Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/e4/3b3bf36b0f829b50c6ebcb8d031583863c59f923d6a6af3d485e470d0fac/watchfiles-1.2.0-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:23282a321c8baf9b3a3c4afff673f9fe65eb7fdc2338d765ccad9d3d1916a5ba", size = 657838, upload-time = "2026-05-18T04:31:06.497Z" },
+    { url = "https://files.pythonhosted.org/packages/21/b1/6cbbb50c1f3002ab568777d44aa21206dfb8807a840990c4037523b51812/watchfiles-1.2.0-cp314-cp314-win32.whl", hash = "sha256:c0db965c5f79aa49fe672d297cf1febc5ad149b658594944f49a54a2b96270a7", size = 275108, upload-time = "2026-05-18T04:30:06.891Z" },
+    { url = "https://files.pythonhosted.org/packages/92/45/190ce6db8dcb4536682cf75d3889ff1a27182a58cb519d343cb6d9ea63d8/watchfiles-1.2.0-cp314-cp314-win_amd64.whl", hash = "sha256:71283b39fd17e5408eb123bd37aeecfd9d54c81fc184421943208aadb879d103", size = 288441, upload-time = "2026-05-18T04:32:12.901Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/3eae1c2313ab08378431d907c3f8095ecca00f3eda33111cf4f0f2591799/watchfiles-1.2.0-cp314-cp314-win_arm64.whl", hash = "sha256:c5c19526f4e54a00f2666a6c0e9e40d582c09e865055ea7378bf0009aab857b3", size = 280684, upload-time = "2026-05-18T04:31:26.902Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/75/fb64e6c25d6b5ca636d03df34ffb1c6e9873303e76d27967e045f8df088f/watchfiles-1.2.0-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:d73a585accffa5ae39c17264c36ec3166d2fad7000c780f5ef83b2722afb9dd2", size = 398857, upload-time = "2026-05-18T04:32:17.108Z" },
+    { url = "https://files.pythonhosted.org/packages/73/4e/9f7adf01754cbf81843722ccfec169d8f26c69778281a302855cecd2ee08/watchfiles-1.2.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ae99b14c5f21e026e0e9d96f40e07d8570ebee6cafd9d8fc318354606daa7a28", size = 392413, upload-time = "2026-05-18T04:31:07.911Z" },
+    { url = "https://files.pythonhosted.org/packages/47/c8/bec626bcc2d69f44b9acb24ce7d60ed7b16b73628eea747fcbd169d8edda/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4429f3b105524a10b72c3a819b091c495d2811d419c1e1e8df773a5a5974f831", size = 452409, upload-time = "2026-05-18T04:31:20.142Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b7/b6362068e81e7c556d155a34c35d40ac3ef42d747b06d7f6e5bf58e359c2/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:43d818978d06062d9b22c4fab2ebe44cf5213d42dc8e62bda8c2760cfa2eeb33", size = 458827, upload-time = "2026-05-18T04:32:06.219Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f8/9a813fa42afb1e0b4625e75f0479826644d3ee8dc287e093799bc01f390c/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b9f732dc58b2dbe69e464ccf8fff7a03b0dd0be439da4c0720d3558527d3d6b4", size = 490104, upload-time = "2026-05-18T04:31:56.034Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/bf/27dfb6094ca4c9aad21298b5525b6c53cb36121ee454331d05161e58d130/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8f200104103feb097de4cab8fe4f5dd18a2026934c7dea98c55a2f5fd6d5a33b", size = 571360, upload-time = "2026-05-18T04:31:57.133Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/39/44a096d67270ea93df91d33877dbe91fbda3aa4f8ec2edf799d93eda8736/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:63ac26eefbf4af1741247d6fb68b11c49a25b2f7413fbd318a83a12aaa9cf666", size = 464644, upload-time = "2026-05-18T04:30:57.33Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/80/c7472203bad6268e3ef1ad260739704847898938ad7ea8b63a5131f46b50/watchfiles-1.2.0-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c4997d4e4a55f0d02b6cde327322daf3a0400e5df6c6b15948994bf72497925", size = 454771, upload-time = "2026-05-18T04:30:48.736Z" },
+    { url = "https://files.pythonhosted.org/packages/51/cf/3b10b268b4b7f0fc26e9debb5eef1998b515887840f444cd3ec80c688755/watchfiles-1.2.0-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:4c887eba18b7945ac73067a8b4a66f21cd46c2539b2bc68588f7be6c7eb6d26b", size = 463494, upload-time = "2026-05-18T04:31:33.826Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/3e/a4302545cd589262a0dc7d140e86f7688eba3f9c72776c27f7e23b8864c4/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:3416ff151bb6b5a8d8d11664974fbef4d9305b9b2957839ab5a270468fd8df30", size = 629383, upload-time = "2026-05-18T04:31:15.596Z" },
+    { url = "https://files.pythonhosted.org/packages/db/99/d5649df0a9a410d45b7c882304d0b790903ac9b6e8f2cfd12114e0c6b9f2/watchfiles-1.2.0-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:0e831a271c035d89789cffc386b6aa1375f39f1cd25eb7ca0997e4970d152fc5", size = 656093, upload-time = "2026-05-18T04:31:58.707Z" },
+    { url = "https://files.pythonhosted.org/packages/92/b9/362702539275019a54dd2e94511b31a9b89c5f9e6a21966de7eb692549fc/watchfiles-1.2.0-cp315-cp315-macosx_10_12_x86_64.whl", hash = "sha256:37a6721cdf3f65dbb13aa9503510ccb4451603ac837e44d265d7992a597e1374", size = 400109, upload-time = "2026-05-18T04:31:16.879Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/75/71d5ba62db781e5587bded1d944c675374bc4aa37ff33d5018d98e8b6538/watchfiles-1.2.0-cp315-cp315-macosx_11_0_arm64.whl", hash = "sha256:2b37d10b5a63bd4d87e18472d80fa525bd670586fae62e5dd580452764879b65", size = 392167, upload-time = "2026-05-18T04:31:28.058Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/01/c66dd95d0423fe30d31820e2d1d5bda773764131bbb6ac0cb1cf303ac328/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0a105bc2283f67e8fbec74253ec2d94925de92ed72c0393f1206bf326b7b7b69", size = 452372, upload-time = "2026-05-18T04:31:00.836Z" },
+    { url = "https://files.pythonhosted.org/packages/91/15/2fe99557e72f85627c6a8eed50d889e8d101623e060a22ad75b875cb932d/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5327989a465505f05cfe06f04fa9d0c2fd5432bb243e10e6f012b1bdca3c8579", size = 459596, upload-time = "2026-05-18T04:31:34.96Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/23/d4acfa0023367428ed48351b3b9b267893037b6cadae55620c61c24bcfd4/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:ecb47f183a8025b2aa18b546725c3657e542112ae9c0613a2af79b4fa8d04ad7", size = 490869, upload-time = "2026-05-18T04:31:59.923Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/5f/3164cbdce06c9fb95c4f7b9e2f9760b5e2797af43a9ecc317ef42a23a278/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8520a4ab0e37f770afc34459c4f8f7019e153f9124dc101c15538365875d1ab2", size = 571641, upload-time = "2026-05-18T04:32:00.948Z" },
+    { url = "https://files.pythonhosted.org/packages/41/e6/85d3731c55e65cd7690f3f803d24c139588aaf863e4bf2148fe7a7fa1a19/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:71cd71740ed2c15211ebb237ced4e39a1cdf6f80566e5fe95428da1626f4fde6", size = 464444, upload-time = "2026-05-18T04:30:34.298Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/7d/562641012b8b09872742c3b8adf9629ec479fd78f8d68ae4a0c13da8add6/watchfiles-1.2.0-cp315-cp315-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f88af53d6ddaf72179ef613ddc905e6f4785f712b49b80b3bef9f3525e6194b4", size = 453593, upload-time = "2026-05-18T04:31:23.464Z" },
+    { url = "https://files.pythonhosted.org/packages/56/fe/cb8ef3d6f929d14158fdaaad9925985b7310abc9384dcd4d82dd0016fb59/watchfiles-1.2.0-cp315-cp315-manylinux_2_31_riscv64.whl", hash = "sha256:cee9d5efd929efdac5f7e58f72b3376f676b64050a91c5b99a7094c5b2317488", size = 465096, upload-time = "2026-05-18T04:31:30.384Z" },
+    { url = "https://files.pythonhosted.org/packages/25/91/80908e835e100527a9267147b08c0eee1fa6ab0ffec15edc04d1d44885f7/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_aarch64.whl", hash = "sha256:b718bf356bbc15e559bd8ef41782b573b8ae0e3f177ab244b440568d7ea02cfb", size = 630638, upload-time = "2026-05-18T04:30:49.89Z" },
+    { url = "https://files.pythonhosted.org/packages/46/4b/95ab2f256bb4af3cb2eb23b9317bda984ee6e0f11733a5c004a6c95b06e3/watchfiles-1.2.0-cp315-cp315-musllinux_1_1_x86_64.whl", hash = "sha256:922c0e019fe68b3ae392965a766b02a71ba1168c932cebc3733cd52c5fe5b377", size = 657684, upload-time = "2026-05-18T04:31:32.027Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Implements spec section 25 Phase 6 acceptance.

Scoring engine under src/stockripper/scoring/:
- reward.py: per-recommendation directional excess return vs SPY, rolled up into AgentScore rows via a PriceProvider Protocol so live runs can plug Alpaca and tests use StaticPriceProvider.
- leaderboard.py: per-track cumulative return, Sharpe, Sortino, Calmar, max drawdown, win rate, turnover from track_snapshots.
- judge_regret.py: selected reward vs best-alternative reward over the same recommendation set per (judge, track, as_of_date).

Dashboard under src/stockripper/dashboard/:
- FastAPI app factory with REST endpoints for runs, tracks, leaderboard, agent scores, judge regret, health.
- WebSocket /ws/events backed by an async EventBus that fans out structured DashboardEvent envelopes.
- Vanilla-JS single-page app at / showing live council feed plus runs, leaderboard, and top agent scores.

Orchestrator wiring:
- window_runner.run_window gained an optional event_emitter kwarg; emits window_started, track_started, agent_completed, recommendation_emitted, judge_decided, action_submitted, track_completed, window_completed. Emission errors are swallowed so the hot path is never broken.

Repository extensions: upsert/list for AgentScore, TrackLeaderboardEntry, JudgeRegretEntry, plus list_recommendations and list_runs for the dashboard endpoints.

CLI additions: stockripper scoring score, scoring leaderboard, scoring regret, dashboard serve.

38 new tests across scoring, repository upserts, event bus, FastAPI endpoints, and window_runner event emission. Suite is 275/275, ruff clean, mypy strict clean.